### PR TITLE
Build Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:16.04 AS build
+
+ARG ROCKSDB_VERSION
+RUN apt-get update -y
+RUN apt-get install -y liblz4-dev libbz2-dev libzstd-dev libsnappy-dev \
+    libz-dev libjemalloc-dev build-essential git curl
+RUN git clone --depth 1 --single-branch --branch v${ROCKSDB_VERSION} \
+    https://github.com/facebook/rocksdb /rocksdb
+WORKDIR /rocksdb
+RUN PORTABLE=1 make static_lib
+RUN strip -g librocksdb.a
+ENV ROCKSDB_HOME /rocksdb
+
+ARG GOLANG_VERSION
+WORKDIR /usr/local
+RUN curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz | tar xfz -
+ENV PATH ${PATH}:/usr/local/go/bin
+
+ARG FAKTORY_VERSION
+ENV CGO_CFLAGS -I${ROCKSDB_HOME}/include
+ENV CGO_LDFLAGS -L${ROCKSDB_HOME} -lrocksdb -llz4 -lbz2 -lzstd -lsnappy -lz -ljemalloc
+ADD . /faktory
+RUN cd /faktory && make prepare
+RUN ln -s /faktory ${HOME}/go/src/github.com/contribsys/faktory
+ENV PATH ${PATH}:/root/go/bin
+WORKDIR /root/go/src/github.com/contribsys/faktory
+RUN make test
+RUN make build
+
+FROM ubuntu:16.04
+COPY --from=build /faktory/faktory /faktory/faktory-cli /
+RUN apt-get update && apt-get install -y liblz4-dev libbz2-dev libzstd-dev \
+    libsnappy-dev libz-dev libjemalloc-dev
+RUN mkdir -p /root/.faktory/db
+
+EXPOSE 7419 7420
+ENTRYPOINT ["/faktory"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+# Ex:
+#   git clone https://github.com/contribsys/faktory.git
+#   cd faktory && git checkout v0.5.0
+#   GOLANG_VERSION=1.9.1 ROCKSDB_VERSION=5.7.3 TAG=0.5.0 docker-compose build
+# That will build an image and tag it like:
+#   contribsys/faktory:0.5.0
+
+version: "3"
+
+services:
+  faktory:
+    image: contribsys/faktory:${TAG}
+    build:
+      context: .
+      args:
+        GOLANG_VERSION: ${GOLANG_VERSION}
+        ROCKSDB_VERSION: ${ROCKSDB_VERSION}


### PR DESCRIPTION
Build a Docker image with the following commands:
```
git clone https://github.com/contribsys/faktory.git
cd faktory && git checkout v0.5.0
GOLANG_VERSION=1.9.1 ROCKSDB_VERSION=5.7.3 TAG=0.5.0 docker-compose build
```
That assumes there is a branch or tag `v0.5.0`.

That will build an image: `contribsys/faktory:0.5.0`

Notice that the image tag is set with an env var _regardless_ of what version of Faktory you have checked out.  So take care that you set a tag that properly corresponds to what you're building.

If you then do a `docker-compose push` it will push the image to Docker Hub for anyone to download and use (assuming you're the owner of `contribsys` on Docker Hub).

Run a container in the foreground like so:
```
docker run --rm -it -p 7419:7419 -p 7420:7420 contribsys/faktory:0.5.0 -b :7419 -no-tls
```

Addresses #13.