### PR TITLE
Store could be nil on EOF in repl.

### DIFF
--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -56,7 +56,9 @@ func repl(path string, store storage.Store) {
 		if er != nil {
 			if io.EOF == er {
 				fmt.Println("")
-				store.Close()
+				if store != nil {
+					store.Close()
+				}
 				os.Exit(0)
 			}
 			fmt.Printf("Error: %s\n", er.Error())


### PR DESCRIPTION
For issue #31 if it's an actual problem and not just my local machine.
If I don't do `mkdir -p ~/.faktory/db` then store is nil and the EOF check bombs.