### PR TITLE
Fix the tick / untick all checkbox at the top of the tables

### DIFF
--- a/webui/static/application.js
+++ b/webui/static/application.js
@@ -26,12 +26,7 @@ $(function() {
   }
 
   $(document).on('click', '.check_all', function() {
-    var checked = $(this).attr('checked');
-    if (checked == 'checked') {
-      $('input[type=checkbox]', $(this).closest('table')).attr('checked', checked);
-    } else {
-      $('input[type=checkbox]', $(this).closest('table')).removeAttr('checked');
-    }
+    $('input[type=checkbox]', $(this).closest('table')).prop('checked', $(this).is(':checked'));
   });
 
   $(document).on("click", "[data-confirm]", function() {


### PR DESCRIPTION
This is using .prop('checked') and .is(':checked')

.attr('checked') didn't work for me, in Chrome or Safari. 