### PR TITLE
Pagination on the queued jobs list is creating a new queue

### DIFF
--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -58,6 +58,12 @@ func TestBasicQueueOps(t *testing.T) {
 	// valid names:
 	_, err = store.GetQueue("A-Za-z0-9_.-")
 	assert.NoError(t, err)
+	_, err = store.GetQueue("-")
+	assert.NoError(t, err)
+	_, err = store.GetQueue("A")
+	assert.NoError(t, err)
+	_, err = store.GetQueue("a")
+	assert.NoError(t, err)
 
 	// invalid names:
 	_, err = store.GetQueue("default?page=1")

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -57,6 +57,7 @@ func TestBasicQueueOps(t *testing.T) {
 
 	// valid names:
 	_, err = store.GetQueue("A-Za-z0-9_.-")
+	assert.NoError(t, err)
 
 	// invalid names:
 	_, err = store.GetQueue("default?page=1")

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -54,6 +54,21 @@ func TestBasicQueueOps(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), cnt)
 	assert.Equal(t, int64(0), q.Size())
+
+	// valid names:
+	_, err = store.GetQueue("A-Za-z0-9_.-")
+
+	// invalid names:
+	_, err = store.GetQueue("default?page=1")
+	assert.Error(t, err)
+	_, err = store.GetQueue("user@example.com")
+	assert.Error(t, err)
+	_, err = store.GetQueue("c&c")
+	assert.Error(t, err)
+	_, err = store.GetQueue("priority|high")
+	assert.Error(t, err)
+	_, err = store.GetQueue("")
+	assert.Error(t, err)
 }
 
 func TestDecentQueueUsage(t *testing.T) {

--- a/storage/rocksdb.go
+++ b/storage/rocksdb.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/contribsys/faktory/util"
 	"github.com/contribsys/gorocksdb"
+	"strings"
 )
 
 type rocksStore struct {
@@ -224,8 +225,15 @@ func (store *rocksStore) init() error {
 
 func (store *rocksStore) GetQueue(name string) (Queue, error) {
 	if name == "" {
-		return nil, fmt.Errorf("Queue name cannot be blank")
+		return nil, fmt.Errorf("queue name cannot be blank")
 	}
+	
+	valid := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
+	invalid := strings.Trim(name, valid)  // strip the valid chars, leaving just the bad ones
+	if len(invalid) > 0 {
+		return nil, fmt.Errorf("queue names can only contain A-Za-z0-9_.-")
+	}
+
 	store.mu.Lock()
 	defer store.mu.Unlock()
 

--- a/webui/pages.go
+++ b/webui/pages.go
@@ -47,7 +47,7 @@ var (
 )
 
 func queueHandler(w http.ResponseWriter, r *http.Request) {
-	name := LAST_ELEMENT.FindStringSubmatch(r.RequestURI)
+	name := LAST_ELEMENT.FindStringSubmatch(r.URL.Path)
 	if name == nil {
 		http.Error(w, "Invalid input", http.StatusBadRequest)
 		return


### PR DESCRIPTION
If you have more than 25 jobs in the `default` queue and navigate to Queues -> Default -> page 2 then the queues page uses the `?page=2` as part of the queue name. 

You'll get a new queue called `default?page=2`

Fixed by passing only the path `/queues/default` path to LAST_ELEMENT, not the full request URI `/queues/default?page=2`