### PR TITLE
Add a Makefile help menu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ before_script:
   - mkdir -p $GOPATH/src/github.com/contribsys && ln -s $HOME/faktory $GOPATH/src/github.com/contribsys/faktory
   - cd $GOPATH/src/github.com/contribsys/faktory && make prepare
 
-script: cd $GOPATH/src/github.com/contribsys/faktory && make
+script: cd $GOPATH/src/github.com/contribsys/faktory && make all

--- a/Makefile
+++ b/Makefile
@@ -211,9 +211,8 @@ upload:	package tag
 	package_cloud push contribsys/faktory/el/7 packaging/output/systemd/$(NAME)-$(VERSION)-$(ITERATION).x86_64.rpm
 	#package_cloud push contribsys/faktory/el/6 packaging/output/upstart/$(NAME)-$(VERSION)-$(ITERATION).x86_64.rpm
 
-# .PHONY: all clean test build package upload
+.PHONY: help all clean test build package upload
 
-.PHONY: help
 
 help:
 		@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This way the Makefile is self-documenting, the developer can select what
make target to run with the help of the descriptions.

This what you get with this PR:

<img width="723" alt="make-menu" src="https://user-images.githubusercontent.com/80530/32205556-df50d45a-bdbd-11e7-9617-34305b2d57fe.png">

I was a bit lost when I opened the project and tried to run different make targets, hopefully, you'll find this useful.