### PR TITLE
Remove unused defaultDelay var in scheduler

### DIFF
--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -19,10 +19,6 @@ type scanner struct {
 	cycles   int64
 }
 
-var (
-	defaultDelay = 1 * time.Second
-)
-
 func (s *scanner) Name() string {
 	return s.name
 }


### PR DESCRIPTION
There's a defaultDelay declared in the scheduler that goes unused. 