### PR TITLE
Add linker strip flags during make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,12 @@ cover:
 	go tool cover -html=cover.out -o coverage.html
 	/Applications/Firefox.app/Contents/MacOS/firefox coverage.html
 
+# https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/
 # we can't cross-compile when using cgo <cry>
 #	@GOOS=linux GOARCH=amd64
 build: clean generate
-	go build -o faktory-cli cmd/faktory-cli/repl.go
-	go build -o faktory cmd/faktory/daemon.go
+	go build -ldflags="-s -w" -o faktory-cli cmd/faktory-cli/repl.go
+	go build -ldflags="-s -w" -o faktory cmd/faktory/daemon.go
 
 megacheck:
 	@megacheck $(shell go list -f '{{ .ImportPath }}'  ./... | grep -ve vendor | paste -sd " " -) || true


### PR DESCRIPTION
Tips from: https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/

These flags keep the symbols required for proper stack traces but remove debug symbols that are normally kept around in go binaries. Everything runs fine, but drops 3.5MB off of the `faktory` binary and ~2MB off of the `faktory-cli` binary on my machine (Mac OSX).

This will probably result in a different build savings on linux systems not only because of the elf v mach-o diference, but because of the fact that we're statically linking on linux.