### PR TITLE
Adding locale preferences to the debug page

### DIFF
--- a/webui/debug.ego
+++ b/webui/debug.ego
@@ -24,64 +24,74 @@ func ego_debug(w io.Writer, req *http.Request) {
   <table class="error table table-bordered table-striped">
     <tbody>
       <tr>
-        <th><%= t(req, "Version") %></th>
-        <td>Faktory <%= faktory.Version %>, RocksDB <%= gorocksdb.RocksDBVersion() %></td>
-      </tr>
-      <tr>
-        <th><%= t(req, "Data Location") %></th>
-        <td><%= stats["name"] %></td>
-      </tr>
-      <tr>
-        <th><%= t(req, "Runtime") %></th>
-        <td>Goroutines: <%= runtime.NumGoroutine() %>, CPUs: <%= runtime.NumCPU() %></td>
-      </tr>
-      <tr>
-        <th><%= t(req, "Memory") %></th>
+        <th><%= t(req, "Locale") %></th>
         <td>
-          Alloc (KB): <%= m.Alloc / 1024 %><br/>
-          Live Objects: <%= m.Mallocs - m.Frees %>
+          <select name="locales" id="faktory_locale">
+            <% for _,locale := range sortedLocaleNames(locales) { %>
+              <option name="<%= locale %>" <% if locale == req.Context().(*DefaultContext).locale { %> selected <% } %> > <%= locale %> </option>
+            <% } %>
+          </select>
         </td>
-      </tr>
-      <tr>
-        <th><%= t(req, "GC") %></th>
-        <td>
-          PauseTotal (µs): <%= m.PauseTotalNs / 1000 %><br/>
-          NumGC: <%= m.NumGC %>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+    </tr>
+    <tr>
+      <th><%= t(req, "Version") %></th>
+      <td>Faktory <%= faktory.Version %>, RocksDB <%= gorocksdb.RocksDBVersion() %></td>
+    </tr>
+    <tr>
+    <th><%= t(req, "Data Location") %></th>
+      <td><%= stats["name"] %></td>
+    </tr>
+    <tr>
+      <th><%= t(req, "Runtime") %></th>
+      <td>Goroutines: <%= runtime.NumGoroutine() %>, CPUs: <%= runtime.NumCPU() %></td>
+    </tr>
+    <tr>
+      <th><%= t(req, "Memory") %></th>
+      <td>
+        Alloc (KB): <%= m.Alloc / 1024 %><br/>
+        Live Objects: <%= m.Mallocs - m.Frees %>
+      </td>
+    </tr>
+    <tr>
+      <th><%= t(req, "GC") %></th>
+      <td>
+        PauseTotal (µs): <%= m.PauseTotalNs / 1000 %><br/>
+        NumGC: <%= m.NumGC %>
+      </td>
+    </tr>
+  </tbody>
+</table>
 </div>
 
 <h3><%= t(req, "Backups") %></h3>
 <div class="table_container">
-  <table class="error table table-bordered table-striped">
-    <thead>
-      <tr>
-        <th>Id</th>
-        <th>Files</th>
-        <th>Size</th>
-        <th>Timestamp</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% err := defaultServer.Store().EachBackup(func(bi storage.BackupInfo) { %>
-      <tr>
-        <td><%= bi.Id %></td>
-        <td><%= bi.FileCount %></td>
-        <td><%= numberWithDelimiter(bi.Size) %></td>
-        <td><%= time.Unix(bi.Timestamp, 0).UTC() %></td>
-      </tr>
-      <% }) %>
-      <% if err != nil { %><%= err.Error() %><% } %>
-    </tbody>
-  </table>
-  <form action="/debug" method="post">
-    <%== csrfTag(req) %>
-    <div class="btn-group pull-left flip">
-      <button class="btn btn-primary" type="submit" name="action" value="backup"><%= t(req, "Backup") %></button>
-    </div>
-  </form>
+<table class="error table table-bordered table-striped">
+  <thead>
+    <tr>
+      <th>Id</th>
+      <th>Files</th>
+      <th>Size</th>
+      <th>Timestamp</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% err := defaultServer.Store().EachBackup(func(bi storage.BackupInfo) { %>
+    <tr>
+      <td><%= bi.Id %></td>
+      <td><%= bi.FileCount %></td>
+      <td><%= numberWithDelimiter(bi.Size) %></td>
+      <td><%= time.Unix(bi.Timestamp, 0).UTC() %></td>
+    </tr>
+    <% }) %>
+    <% if err != nil { %><%= err.Error() %><% } %>
+  </tbody>
+</table>
+<form action="/debug" method="post">
+  <%== csrfTag(req) %>
+  <div class="btn-group pull-left flip">
+    <button class="btn btn-primary" type="submit" name="action" value="backup"><%= t(req, "Backup") %></button>
+  </div>
+</form>
 </div>
 
 <h3><%= t(req, "Disk Usage") %></h3>

--- a/webui/helpers.go
+++ b/webui/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -298,4 +299,15 @@ func failedHistory(req *http.Request) string {
 		return err.Error()
 	}
 	return string(str)
+}
+
+func sortedLocaleNames(locales map[string]map[string]string) []string {
+	names := make(sort.StringSlice, len(locales))
+	i := 0
+	for locale, _ := range locales {
+		names[i] = locale
+		i++
+	}
+	names.Sort()
+	return names
 }

--- a/webui/static/application.js
+++ b/webui/static/application.js
@@ -37,6 +37,10 @@ $(function() {
     $($(this).attr('data-target')).toggle();
   });
 
+  $(document).on("change","#faktory_locale", function() {
+    document.cookie = "faktory_locale="+$("#faktory_locale").find(":selected").text();
+    location.reload();
+  })
   updateFuzzyTimes($('body').data('locale'));
 });
 

--- a/webui/web.go
+++ b/webui/web.go
@@ -199,7 +199,20 @@ func Setup(pass http.HandlerFunc, debug bool) http.HandlerFunc {
 		start := time.Now()
 
 		// negotiate the language to be used for rendering
-		locale := localeFromHeader(r.Header.Get("Accept-Language"))
+
+		// set locale via cookie
+		localeCookie, _ := r.Cookie("faktory_locale")
+
+		var locale string
+		if localeCookie != nil {
+			locale = localeCookie.Value
+		}
+
+		if locale == "" {
+			// fall back to browser language
+			locale = localeFromHeader(r.Header.Get("Accept-Language"))
+		}
+
 		w.Header().Set("Content-Language", locale)
 
 		dctx := &DefaultContext{


### PR DESCRIPTION
This commit allows users to select their preferred locale from the debug page.  This adds a new row to the debugging table with a select box with all available locales in the system.  Changing the selection automatically reloads the browser into the selected locale.  The user's preference is persisted by a simple cookie, which overrides the browser `Accept-Language` header.