### PR TITLE
Protocol version 2 changes

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,6 +41,10 @@ type ClientData struct {
 	Labels   []string `json:"labels"`
 	// Hash is hex(sha256(password + nonce))
 	PasswordHash string `json:"pwdhash"`
+	// The protocol version used by this client.
+	// The server can reject this connection if the version will not work
+	// The server advertises its protocol version in the HI.
+	Version int `json:"v"`
 }
 
 type Server struct {
@@ -151,15 +155,22 @@ func Dial(srv *Server, password string) (*Client, error) {
 	if strings.HasPrefix(line, "HI ") {
 		str := strings.TrimSpace(line)[3:]
 
-		var hi map[string]string
+		var hi map[string]interface{}
 		err = json.Unmarshal([]byte(str), &hi)
 		if err != nil {
 			conn.Close()
 			return nil, err
 		}
-		salt, ok := hi["s"]
+
+		salt, ok := hi["s"].(string)
 		if ok {
-			client.PasswordHash = fmt.Sprintf("%x", sha256.Sum256([]byte(password+salt)))
+			iter := 1
+			iterVal, ok := hi["i"]
+			if ok {
+				iter = int(iterVal.(float64))
+			}
+
+			client.PasswordHash = hash(password, salt, iter)
 		}
 	} else {
 		conn.Close()
@@ -327,6 +338,7 @@ func emptyClientData() *ClientData {
 	client.Pid = os.Getpid()
 	client.Wid = RandomProcessWid
 	client.Labels = []string{"golang"}
+	client.Version = 2
 	return client
 }
 
@@ -420,4 +432,17 @@ func readResponse(rdr *bufio.Reader) ([]byte, error) {
 		//util.Debugf("< %s%s", string(chr), string(line))
 		return line, nil
 	}
+}
+
+func hash(pwd, salt string, iterations int) string {
+	bytes := []byte(pwd + salt)
+	var hash [32]byte
+
+	hash = sha256.Sum256(bytes)
+	if iterations > 1 {
+		for i := 1; i < iterations; i++ {
+			hash = sha256.Sum256(hash[:])
+		}
+	}
+	return fmt.Sprintf("%x", hash)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -107,7 +107,7 @@ func withFakeServer(t *testing.T, fn func(chan string, chan string, string)) {
 		conn, err := listener.Accept()
 		assert.NoError(t, err)
 		conn.SetDeadline(time.Now().Add(1 * time.Second))
-		conn.Write([]byte("+HI {\"v\":\"1\",\"s\":\"123\"}\r\n"))
+		conn.Write([]byte("+HI {\"v\":2,\"s\":\"123\",\"i\":123}\r\n"))
 		for {
 			buf := bufio.NewReader(conn)
 			line, err := buf.ReadString('\n')

--- a/server/commands.go
+++ b/server/commands.go
@@ -233,7 +233,7 @@ func heartbeat(c *Connection, s *Server, cmd string) {
 		return
 	}
 
-	var worker ClientWorker
+	var worker ClientData
 	data := cmd[5:]
 	err := json.Unmarshal([]byte(data), &worker)
 	if err != nil {
@@ -254,6 +254,6 @@ func heartbeat(c *Connection, s *Server, cmd string) {
 	if entry.state == Running {
 		c.Ok()
 	} else {
-		c.Result([]byte(fmt.Sprintf(`{"signal":"%s"}`, stateSignal(entry.state))))
+		c.Result([]byte(fmt.Sprintf(`{"state":"%s"}`, stateString(entry.state))))
 	}
 }

--- a/server/connection.go
+++ b/server/connection.go
@@ -13,7 +13,7 @@ import (
 // Shout out to antirez for his nice design document on it.
 // https://redis.io/topics/protocol
 type Connection struct {
-	client *ClientWorker
+	client *ClientData
 	conn   io.WriteCloser
 	buf    *bufio.Reader
 }

--- a/server/connection_test.go
+++ b/server/connection_test.go
@@ -58,14 +58,14 @@ func dummyConnection() *Connection {
 	wc := &TestingWriteCloser{output: writeBuffer, Writer: bufio.NewWriter(writeBuffer)}
 
 	return &Connection{
-		client: dummyClientWorker(),
+		client: dummyClientData(),
 		conn:   wc,
 		buf:    bufio.NewReader(strings.NewReader("")),
 	}
 }
 
-func dummyClientWorker() *ClientWorker {
-	return &ClientWorker{
+func dummyClientData() *ClientData {
+	return &ClientData{
 		Hostname:      "foobar.example.com",
 		Wid:           "123k1h23kh",
 		Pid:           70086,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -49,13 +49,14 @@ func TestServerStart(t *testing.T) {
 		_, err = buf.ReadString('\n')
 		assert.NoError(t, err)
 
-		var client ClientWorker
+		var client ClientData
 		hs, err := os.Hostname()
 		assert.NoError(t, err)
 		client.Hostname = hs
 		client.Pid = os.Getpid()
 		client.Wid = strconv.FormatInt(rand.Int63(), 10)
 		client.Labels = []string{"blue", "seven"}
+		client.Version = 2
 
 		val, err := json.Marshal(client)
 		assert.NoError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -48,10 +48,6 @@ func TestServerStart(t *testing.T) {
 
 		_, err = buf.ReadString('\n')
 		assert.NoError(t, err)
-		// salt := strings.TrimSpace(result)
-		// if salt != "HI" {
-		// 	// needs password
-		// }
 
 		var client ClientWorker
 		hs, err := os.Hostname()
@@ -60,8 +56,6 @@ func TestServerStart(t *testing.T) {
 		client.Pid = os.Getpid()
 		client.Wid = strconv.FormatInt(rand.Int63(), 10)
 		client.Labels = []string{"blue", "seven"}
-		// password is "123456" also
-		client.PasswordHash = "958d51602bbfbd18b2a084ba848a827c29952bfef170c936419b0922994c0589"
 
 		val, err := json.Marshal(client)
 		assert.NoError(t, err)

--- a/server/workers.go
+++ b/server/workers.go
@@ -45,6 +45,7 @@ type ClientWorker struct {
 	Pid          int      `json:"pid"`
 	Labels       []string `json:"labels"`
 	PasswordHash string   `json:"pwdhash"`
+	Version      uint8    `json:"v"`
 	StartedAt    time.Time
 
 	lastHeartbeat time.Time

--- a/server/workers_test.go
+++ b/server/workers_test.go
@@ -8,23 +8,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClientWorker(t *testing.T) {
+func TestClientData(t *testing.T) {
 	t.Parallel()
 
-	cw, err := clientWorkerFromHello("")
+	cw, err := clientDataFromHello("")
 	assert.Error(t, err)
 	assert.Nil(t, cw)
 
-	cw, err = clientWorkerFromHello("{")
+	cw, err = clientDataFromHello("{")
 	assert.Error(t, err)
 	assert.Nil(t, cw)
 
-	cw, err = clientWorkerFromHello("{}")
+	cw, err = clientDataFromHello("{}")
 	assert.NoError(t, err)
 	assert.NotNil(t, cw)
 
 	ahoy := `{"hostname":"MikeBookPro.local","wid":"78629a0f5f3f164f","pid":40275,"labels":["blue","seven"],"salt":"123456","pwdhash":"958d51602bbfbd18b2a084ba848a827c29952bfef170c936419b0922994c0589"}`
-	cw, err = clientWorkerFromHello(ahoy)
+	cw, err = clientDataFromHello(ahoy)
 	assert.NoError(t, err)
 	assert.NotNil(t, cw)
 
@@ -50,14 +50,14 @@ func TestClientWorker(t *testing.T) {
 func TestHeartbeats(t *testing.T) {
 	t.Parallel()
 
-	beatsByMe := map[string]*ClientWorker{}
+	beatsByMe := map[string]*ClientData{}
 	var mu sync.RWMutex
 
 	assert.Equal(t, 0, len(beatsByMe))
 	reapHeartbeats(beatsByMe, &mu)
 
 	ahoy := `{"hostname":"MikeBookPro.local","wid":"78629a0f5f3f164f","pid":40275,"labels":["blue","seven"],"salt":"123456","pwdhash":"958d51602bbfbd18b2a084ba848a827c29952bfef170c936419b0922994c0589"}`
-	client, err := clientWorkerFromHello(ahoy)
+	client, err := clientDataFromHello(ahoy)
 	assert.NoError(t, err)
 
 	before := time.Now()

--- a/test/go_system_test.go
+++ b/test/go_system_test.go
@@ -3,9 +3,11 @@ package tester
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -47,6 +49,9 @@ func TestSystem(t *testing.T) {
 	}()
 
 	s.WaitUntilInitialized()
+
+	// this is a worker process so we need to set the global WID before connecting
+	faktory.RandomProcessWid = strconv.FormatInt(rand.Int63(), 32)
 
 	each := 10000
 	start := time.Now()

--- a/webui/busy.ego
+++ b/webui/busy.ego
@@ -36,7 +36,7 @@ func ego_busy(w io.Writer, req *http.Request) {
       <th><%= t(req, "Busy") %></th>
       <th>&nbsp;</th>
     </thead>
-    <% busyWorkers(func(worker *server.ClientWorker) { %>
+    <% busyWorkers(func(worker *server.ClientData) { %>
       <tr>
         <td>
           <code>
@@ -44,7 +44,6 @@ func ego_busy(w io.Writer, req *http.Request) {
           </code>
         </td>
         <td>
-          
           <code><%= worker.Hostname %>:<%= worker.Pid %></code>
           <% for _, label := range worker.Labels { %>
             <span class="label label-info"><%= label %></span>

--- a/webui/helpers.go
+++ b/webui/helpers.go
@@ -168,7 +168,7 @@ func busyReservations(fn func(worker *server.Reservation)) {
 	}
 }
 
-func busyWorkers(fn func(proc *server.ClientWorker)) {
+func busyWorkers(fn func(proc *server.ClientData)) {
 	for _, worker := range defaultServer.Heartbeats() {
 		fn(worker)
 	}

--- a/webui/pages_test.go
+++ b/webui/pages_test.go
@@ -310,12 +310,13 @@ func TestBusy(t *testing.T) {
 	assert.NoError(t, err)
 
 	wid := "1239123oim,bnsad"
-	wrk := &server.ClientWorker{
+	wrk := &server.ClientData{
 		Hostname:  "foobar.local",
 		Pid:       12345,
 		Wid:       wid,
 		Labels:    []string{"bubba"},
 		StartedAt: time.Now(),
+		Version:   2,
 	}
 	defaultServer.Heartbeats()[wid] = wrk
 


### PR DESCRIPTION
* A nil response, e.g. FETCH response, is now correctly sent as `$-1\r\n`, per RESP docs.
* Add `HI "i"` random hash iterations count, for defense against rainbow tables
* Change `HI "v"` value in JSON from String to int, this was a “whoops” by me
* Clients should advise the server of their requested protocol version with `HELLO "v"`.  This way the server can elect to kill the connection immediately to disallow old clients.
* The`"signal"` JSON key within the BEAT response has been renamed to "state" to better reflect intent.

TLS socket support has been removed from the Faktory server.  The Faktory client APIs can still be configured to connect to a TLS socket.