### PR TITLE
Remove TLS server support

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -22,7 +22,6 @@ type CmdOptions struct {
 	ConfigDirectory  string
 	LogLevel         string
 	StorageDirectory string
-	DisableTls       bool
 	Password         string
 }
 
@@ -33,7 +32,7 @@ var (
 )
 
 func ParseArguments() CmdOptions {
-	defaults := CmdOptions{"localhost:7419", "development", "/etc/faktory", "info", "/var/lib/faktory/db", false, ""}
+	defaults := CmdOptions{"localhost:7419", "development", "/etc/faktory", "info", "/var/lib/faktory/db", ""}
 
 	log.SetFlags(0)
 	log.Println(faktory.Name, faktory.Version)
@@ -47,7 +46,6 @@ func ParseArguments() CmdOptions {
 	flag.StringVar(&defaults.Binding, "b", "localhost:7419", "Network binding")
 	flag.StringVar(&defaults.LogLevel, "l", "info", "Logging level (error, warn, info, debug)")
 	flag.StringVar(&defaults.Environment, "e", "development", "Environment (development, staging, production, etc)")
-	flag.BoolVar(&defaults.DisableTls, "no-tls", false, "Disable TLS, I don't want encryption")
 
 	// undocumented on purpose, we don't want people changing these if possible
 	flag.StringVar(&defaults.StorageDirectory, "d", "/var/lib/faktory/db", "Storage directory")
@@ -78,7 +76,6 @@ func help() {
 	log.Println("-b [binding]\tNetwork binding (use :7419 to listen on all interfaces), default: localhost:7419")
 	log.Println("-e [env]\tSet environment (development, staging, production), default: development")
 	log.Println("-l [level]\tSet logging level (warn, info, debug, verbose), default: info")
-	log.Println("-no-tls\tDisable TLS for network sockets, I know what I'm doing")
 	log.Println("-v\t\tShow version and license information")
 	log.Println("-h\t\tThis help screen")
 }

--- a/cmd/faktory/daemon.go
+++ b/cmd/faktory/daemon.go
@@ -22,7 +22,6 @@ func main() {
 		StorageDirectory: opts.StorageDirectory,
 		ConfigDirectory:  opts.ConfigDirectory,
 		Environment:      opts.Environment,
-		DisableTls:       opts.DisableTls,
 	})
 	if err != nil {
 		fmt.Println(err)

--- a/server/security.go
+++ b/server/security.go
@@ -1,12 +1,8 @@
 package server
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"fmt"
 	"io/ioutil"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/contribsys/faktory/util"
@@ -32,65 +28,4 @@ func fetchPassword(configDir string) (string, error) {
 	}
 
 	return "", nil
-}
-
-func tlsConfig(binding string, forceTLS bool, configDir string) (*tls.Config, error) {
-	return findTlsConfigIn(binding, forceTLS, []string{configDir + "/tls"})
-}
-
-func findTlsConfigIn(binding string, disableTls bool, dirs []string) (*tls.Config, error) {
-	// TLS is optional when binding to something that matches "localhost:"
-	optional, err := regexp.Match("\\Alocalhost:", []byte(binding))
-	if err != nil {
-		return nil, err
-	}
-
-	if disableTls {
-		optional = true
-	}
-
-	if optional {
-		return nil, nil
-	}
-
-	var tlscfg *tls.Config
-
-	for _, dir := range dirs {
-		if dir == "" {
-			continue
-		}
-
-		exists, err := util.FileExists(dir + "/public.crt")
-		if err != nil {
-			return nil, err
-		}
-		if !exists {
-			continue
-		}
-
-		cert, err := tls.LoadX509KeyPair(dir+"/public.crt", dir+"/private.key")
-		if err != nil {
-			return nil, err
-		}
-		tlscfg = &tls.Config{
-			RootCAs:      nil,
-			Certificates: []tls.Certificate{cert},
-		}
-		exists, err = util.FileExists(dir + "/ca.crt")
-		if err != nil {
-			return nil, err
-		}
-		if exists {
-			pemData, err := ioutil.ReadFile(dir + "/ca.crt")
-			if err != nil {
-				return nil, err
-			}
-			cas := x509.NewCertPool()
-			cas.AppendCertsFromPEM(pemData)
-			tlscfg.RootCAs = cas
-		}
-		return tlscfg, nil
-	}
-
-	return nil, fmt.Errorf("TLS certificates not found in %v", dirs)
 }

--- a/server/security_test.go
+++ b/server/security_test.go
@@ -1,56 +1,10 @@
 package server
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
-	"github.com/contribsys/faktory"
-	"github.com/contribsys/faktory/util"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestTlsConfig(t *testing.T) {
-	// no TLS
-	cfg, err := tlsConfig("localhost:7419", false, "/etc/faktory")
-	assert.Nil(t, cfg)
-	assert.NoError(t, err)
-
-	// without CA bundle
-	cfg, err = findTlsConfigIn(":7419", false, []string{"../test/tls/1"})
-	assert.NotNil(t, cfg)
-	assert.NoError(t, err)
-
-	// with CA bundle
-	cfg, err = findTlsConfigIn(":7419", false, []string{"../test/tls/2"})
-	assert.NotNil(t, cfg)
-	assert.NoError(t, err)
-
-	// the certs are self-signed for "acme.example.com"
-	cfg.BuildNameToCertificate()
-	assert.Equal(t, 1, len(cfg.NameToCertificate))
-	assert.NotNil(t, cfg.NameToCertificate["acme.example.com"])
-
-	// requires certs, but not there
-	cfg, err = findTlsConfigIn(":7419", false, []string{"/tmp"})
-	assert.Nil(t, cfg)
-	assert.Error(t, err, "not found")
-
-	// does not require certs, and not there
-	cfg, err = findTlsConfigIn("localhost:7419", false, []string{"/tmp"})
-	assert.Nil(t, cfg)
-	assert.NoError(t, err)
-
-	// disable TLS, no certs
-	cfg, err = findTlsConfigIn("localhost:7419", true, []string{"/tmp"})
-	assert.Nil(t, cfg)
-	assert.NoError(t, err)
-
-	// disable TLS, certs
-	cfg, err = findTlsConfigIn(":7419", true, []string{"../test/tls/1"})
-	assert.Nil(t, cfg)
-	assert.NoError(t, err)
-}
 
 func TestPasswords(t *testing.T) {
 	pwd, err := fetchPassword("../test/auth")
@@ -60,36 +14,4 @@ func TestPasswords(t *testing.T) {
 	pwd, err = fetchPassword("../test/foo")
 	assert.NoError(t, err)
 	assert.Equal(t, "", pwd)
-}
-
-/*
- * This sets up a full server running TLS+password, connects to it with a client
- * and tries to run a few commands.  A basic integration test.
- */
-func TestFullTLS(t *testing.T) {
-	ok, err := util.FileExists(os.ExpandEnv("$HOME/.faktory/tls/public.crt"))
-	assert.NoError(t, err)
-	if !ok {
-		fmt.Println("Skipping full TLS test, cert not found")
-		return
-	}
-
-	os.Setenv("FAKTORY_PASSWORD", "password123")
-	runServer("localhost.contribsys.com:7520", func() {
-		svr := faktory.DefaultServer()
-		svr.Address = "localhost.contribsys.com:7520"
-
-		client, err := faktory.Dial(svr, "password123")
-		assert.NoError(t, err)
-
-		result, err := client.Info()
-		assert.NoError(t, err)
-		assert.NotNil(t, result)
-
-		err = client.Flush()
-		assert.NoError(t, err)
-		x, err := client.Beat()
-		assert.NoError(t, err)
-		assert.Equal(t, "", x)
-	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"crypto/sha256"
 	"crypto/subtle"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,7 +29,6 @@ type ServerOptions struct {
 	StorageDirectory string
 	ConfigDirectory  string
 	Environment      string
-	DisableTls       bool
 }
 
 type RuntimeStats struct {
@@ -42,10 +40,9 @@ type RuntimeStats struct {
 }
 
 type Server struct {
-	Options   *ServerOptions
-	Stats     *RuntimeStats
-	TLSConfig *tls.Config
-	Password  string
+	Options  *ServerOptions
+	Stats    *RuntimeStats
+	Password string
 
 	listener   net.Listener
 	store      storage.Store
@@ -80,23 +77,11 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 		initialized: make(chan bool, 1),
 	}
 
-	tlsC, err := tlsConfig(s.Options.Binding, s.Options.DisableTls, s.Options.ConfigDirectory)
+	pwd, err := fetchPassword(s.Options.ConfigDirectory)
 	if err != nil {
 		return nil, err
 	}
-	if tlsC != nil {
-		s.TLSConfig = tlsC
-		pwd, err := fetchPassword(s.Options.ConfigDirectory)
-		if err != nil {
-			return nil, err
-		}
-		s.Password = pwd
-
-		// if we need TLS, we need a password too
-		if s.Password == "" {
-			return nil, fmt.Errorf("Cannot enable TLS without a password")
-		}
-	}
+	s.Password = pwd
 
 	return s, nil
 }
@@ -116,21 +101,11 @@ func (s *Server) Start() error {
 	}
 	defer store.Close()
 
-	var listener net.Listener
-
-	if s.TLSConfig != nil {
-		listener, err = tls.Listen("tcp", s.Options.Binding, s.TLSConfig)
-		if err != nil {
-			return err
-		}
-		util.Infof("Now listening securely at %s, press Ctrl-C to stop", s.Options.Binding)
-	} else {
-		listener, err = net.Listen("tcp", s.Options.Binding)
-		if err != nil {
-			return err
-		}
-		util.Infof("Now listening at %s, press Ctrl-C to stop", s.Options.Binding)
+	listener, err := net.Listen("tcp", s.Options.Binding)
+	if err != nil {
+		return err
 	}
+	util.Infof("Now listening at %s, press Ctrl-C to stop", s.Options.Binding)
 
 	s.mu.Lock()
 	s.store = store

--- a/webui/web.go
+++ b/webui/web.go
@@ -70,15 +70,9 @@ func FireItUp(svr *server.Server) error {
 			ReadTimeout:    1 * time.Second,
 			WriteTimeout:   10 * time.Second,
 			MaxHeaderBytes: 1 << 20,
-			TLSConfig:      svr.TLSConfig,
 		}
-		if s.TLSConfig == nil {
-			util.Info("Web server now listening on port 7420")
-			log.Fatal(s.ListenAndServe())
-		} else {
-			util.Info("Web server now listening securely on port 7420")
-			log.Fatal(s.ListenAndServeTLS("", ""))
-		}
+		util.Info("Web server now listening on port 7420")
+		log.Fatal(s.ListenAndServe())
 	}()
 	return nil
 }


### PR DESCRIPTION
There are many other ways to add encryption which are orthogonal to Faktory.
It is not supported to have Faktory listening on the open Internet.

- Use stunnel/spiped with Faktory inside a container
- Set up an SSH tunnel between machines

It’s possible we will add back in direct TLS support but not until we get a lot more production feedback from users so we have a clear real world direction and not a vague sense.

See also #64