### PR TITLE
Add separate target for loadtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ cover:
 build: clean generate
 	go build -ldflags="-s -w" -o faktory-cli cmd/faktory-cli/repl.go
 	go build -ldflags="-s -w" -o faktory cmd/faktory/daemon.go
+
+# this is a separate target because loadtest doesn't need rocksdb or webui
+build_load:
 	go build -ldflags="-s -w" -o loadtest test/load/main.go
 
 megacheck:


### PR DESCRIPTION
loadtest is a client-only binary, and thus does not need any of the Faktory dependencies (e.g., webui or rocksdb). This makes it much easier for developers to load test a Faktory server run with `make drun` by not forcing them to also sort out and build all the dependencies.