### PR TITLE
Enable running Docker Faktory server with password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ dimg: ## Make a Docker image for the current version
 	GOLANG_VERSION=1.9.1 ROCKSDB_VERSION=5.7.3 TAG=$(VERSION) docker-compose build
 
 drun: ## Run Faktory in a local Docker image, see also "make dimg"
-	docker run --rm -it -p 7419:7419 -p 7420:7420 contribsys/faktory:$(VERSION) -b :7419
+	docker run --rm -it -e "FAKTORY_PASSWORD=${PASSWORD}" -p 7419:7419 -p 7420:7420 contribsys/faktory:$(VERSION) -b :7419
 
 generate:
 	go generate github.com/contribsys/faktory/webui


### PR DESCRIPTION
This allows using `make drun` to start the server with a password without editing the Makefile. Specifically, you can now do:

```
make PASSWORD=test drun
```

And the server will run with the password `test`. The old invocation of

```
make drun
```

Will run without a password. This is because the server binary determines whether a password is set or not by whether or not it is the empty string: https://github.com/contribsys/faktory/blob/00eb4f6c/server/security.go#L30