### PR TITLE
Hook up store stats to server stats

### DIFF
--- a/server/commands.go
+++ b/server/commands.go
@@ -139,7 +139,6 @@ func fetch(c *Connection, s *Server, cmd string) {
 			c.Error(cmd, err)
 			return
 		}
-		atomic.AddInt64(&s.Stats.Processed, 1)
 		c.Result(res)
 	} else {
 		c.Result(nil)
@@ -166,6 +165,7 @@ func ack(c *Connection, s *Server, cmd string) {
 		return
 	}
 
+	s.store.Success()
 	c.Ok()
 }
 
@@ -195,8 +195,8 @@ func CurrentState(s *Server) (map[string]interface{}, error) {
 		"server_utc_time": time.Now().UTC().Format("03:04:05 UTC"),
 		"faktory": map[string]interface{}{
 			"default_size":    defalt.Size(),
-			"total_failures":  atomic.LoadInt64(&s.Stats.Failures),
-			"total_processed": atomic.LoadInt64(&s.Stats.Processed),
+			"total_failures":  store.Failures(),
+			"total_processed": store.Processed(),
 			"total_enqueued":  totalQueued,
 			"total_queues":    totalQueues,
 			"tasks":           s.taskRunner.Stats()},

--- a/server/retry.go
+++ b/server/retry.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sync/atomic"
 	"time"
 
 	"github.com/contribsys/faktory"
@@ -101,7 +100,7 @@ func (s *Server) Fail(jid, msg, errtype string, backtrace []string) error {
 
 	err = s.store.Retries().AddElement(when, job.Jid, bytes)
 	if err == nil {
-		atomic.AddInt64(&s.Stats.Failures, 1)
+		s.store.Failure()
 	}
 	return err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -32,8 +32,6 @@ type ServerOptions struct {
 }
 
 type RuntimeStats struct {
-	Processed   int64
-	Failures    int64
 	Connections int64
 	Commands    int64
 	StartedAt   time.Time

--- a/storage/rocksdb.go
+++ b/storage/rocksdb.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"regexp"
 
@@ -104,6 +105,14 @@ func (store *rocksStore) Stats() map[string]string {
 		"stats": store.db.GetProperty("rocksdb.stats"),
 		"name":  store.db.Name(),
 	}
+}
+
+func (store *rocksStore) Processed() int64 {
+	return atomic.LoadInt64(&store.history.TotalProcessed)
+}
+
+func (store *rocksStore) Failures() int64 {
+	return atomic.LoadInt64(&store.history.TotalFailures)
 }
 
 // queues are iterated in sorted, lexigraphical order

--- a/storage/types.go
+++ b/storage/types.go
@@ -25,6 +25,10 @@ type Store interface {
 	EnqueueFrom(SortedSet, []byte) error
 
 	History(days int, fn func(day string, procCnt int64, failCnt int64)) error
+	Success() error
+	Processed() int64
+	Failure() error
+	Failures() int64
 
 	// creates a backup of the current database
 	Backup() error

--- a/test/go_system_test.go
+++ b/test/go_system_test.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -69,8 +68,8 @@ func TestSystem(t *testing.T) {
 	wg.Wait()
 	s.Stop(nil)
 
-	assert.Equal(t, int64(3*each), atomic.LoadInt64(&s.Stats.Processed))
-	assert.Equal(t, int64(3*(each/100)), atomic.LoadInt64(&s.Stats.Failures))
+	assert.Equal(t, int64(3*each), s.Store().Processed())
+	assert.Equal(t, int64(3*(each/100)), s.Store().Failures())
 }
 
 func pushAndPop(t *testing.T, count int) {

--- a/webui/pages_test.go
+++ b/webui/pages_test.go
@@ -36,7 +36,6 @@ func TestStats(t *testing.T) {
 	assert.NoError(t, err)
 
 	defaultServer.Stats.StartedAt = time.Now().Add(-1234567 * time.Second)
-	defaultServer.Stats.Processed = 123
 
 	w := httptest.NewRecorder()
 	statsHandler(w, req)
@@ -50,10 +49,6 @@ func TestStats(t *testing.T) {
 	s := content["server"].(map[string]interface{})
 	uid := s["uptime"].(float64)
 	assert.Equal(t, float64(1234567), uid)
-
-	s = content["faktory"].(map[string]interface{})
-	proc := s["total_processed"].(float64)
-	assert.Equal(t, float64(123), proc)
 }
 
 func TestQueues(t *testing.T) {

--- a/webui/summary.ego
+++ b/webui/summary.ego
@@ -7,11 +7,11 @@ func ego_summary(w io.Writer, req *http.Request) {
 %>
 <ul class="list-unstyled summary row">
   <li class="processed col-sm-1">
-    <span class="count"><%= numberWithDelimiter(defaultServer.Stats.Processed) %></span>
+    <span class="count"><%= numberWithDelimiter(defaultServer.Store().Processed()) %></span>
     <span class="desc"><%= t(req, "Processed") %></span>
   </li>
   <li class="failed col-sm-1">
-    <span class="count"><%= numberWithDelimiter(defaultServer.Stats.Failures) %></span>
+    <span class="count"><%= numberWithDelimiter(defaultServer.Store().Failures()) %></span>
     <span class="desc"><%= t(req, "Failed") %></span>
   </li>
   <li class="busy col-sm-1">


### PR DESCRIPTION
Fixes #85 

The stats counter in the store wasn't actually hooked up to anything. Also, by moving the `Success` invocation to `ack` instead of `fetch`, we should have a more accurate idea of actual "processed" jobs, rather than just fetched jobs.