### PR TITLE
use .args on the queue detail page

### DIFF
--- a/webui/queue.ego
+++ b/webui/queue.ego
@@ -39,7 +39,7 @@ func ego_queue(w io.Writer, req *http.Request, q storage.Queue, count, currentPa
         <td><input type="checkbox" name="bkey" value="<%= base64.RawURLEncoding.EncodeToString(key) %>" /></td>
         <td><%= job.Type %></td>
         <td><%= job.Priority %></td>
-        <td><code><%= job.Args %></code></td>
+        <td><div class="args"><code><%= job.Args %></code></div></td>
       </tr>
     <% }) %>
   </table>


### PR DESCRIPTION
The other views have job arguments wrapped in `<div class="args">` so they scroll, but this wasn't used on the individual queue page