### PR TITLE
Integrate with chzyer/readline package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/chzyer/readline"
+  packages = ["."]
+  revision = "62c6fe6193755f722b8b8788aa7357be55a50ff1"
+  version = "v1.4"
+
+[[projects]]
   name = "github.com/contribsys/gorocksdb"
   packages = ["."]
   revision = "65923dcb8c3df7681d26491e7ae40abf7f3b53c5"
@@ -39,6 +45,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fd74b45ceff28bf452c9a049dbef830eeddc8ec4a97e430c7b3e33abd81b60cd"
+  inputs-digest = "a0eefbd45a8908fa96e2ab89e806a7db3558a1a871b2158f2be6e77d4c3436b5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/faktory-cli/repl.go
+++ b/cmd/faktory-cli/repl.go
@@ -95,7 +95,7 @@ func repl(path string, store storage.Store) {
 
 	l, err := readline.NewEx(&readline.Config{
 		Prompt:          "> ",
-		HistoryFile:     dir + "/.faktory/cli.history",
+		HistoryFile:     dir + "/.local/.faktory-cli.history",
 		AutoComplete:    completer,
 		InterruptPrompt: "^C",
 		EOFPrompt:       "exit",

--- a/cmd/faktory-cli/repl.go
+++ b/cmd/faktory-cli/repl.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"os/user"
 	"strconv"
 	"strings"
 	"syscall"
@@ -89,9 +90,12 @@ func repl(path string, store storage.Store) {
 		readline.PcItem("help"),
 	)
 
+	usr, _ := user.Current()
+	dir := usr.HomeDir
+
 	l, err := readline.NewEx(&readline.Config{
 		Prompt:          "> ",
-		HistoryFile:     "/tmp/faktory.tmp",
+		HistoryFile:     dir + "/.faktory/cli.history",
 		AutoComplete:    completer,
 		InterruptPrompt: "^C",
 		EOFPrompt:       "exit",

--- a/cmd/faktory-cli/repl_test.go
+++ b/cmd/faktory-cli/repl_test.go
@@ -84,10 +84,10 @@ func TestInteractiveOutputs(t *testing.T) {
 		Arg    string
 		Output string
 	}{
-		{"flush", "> OK> "},
-		{"purge", "> OK> "},
-		{"version", "> Faktory " + client.Version + ", RocksDB " + gorocksdb.RocksDBVersion() + "> "},
-		{"help", ">" + " Valid commands:flush\t\t\tflush all job data from database, useful for testingbackup\t\t\tcreate a new backuppurge [keep]\t\tpurge old backups, keep [N] newest backups, default 24restore *\t\trestore the database from the newest backuprepair *\t\trun RocksDB's internal repair function to recover from data issuesversionhelp* Requires an immediate restart after running command." + "> "},
+		{"flush", "OK"},
+		{"purge", "OK"},
+		{"version", "Faktory " + client.Version + ", RocksDB " + gorocksdb.RocksDBVersion()},
+		{"help", "Valid commands:flush\t\t\tflush all job data from database, useful for testingbackup\t\t\tcreate a new backuppurge [keep]\t\tpurge old backups, keep [N] newest backups, default 24restore *\t\trestore the database from the newest backuprepair *\t\trun RocksDB's internal repair function to recover from data issuesversionhelp* Requires an immediate restart after running command."},
 	}
 
 	for _, ts := range tests {
@@ -121,7 +121,8 @@ func TestInteractiveOutputs(t *testing.T) {
 			bkp = fmt.Sprintf("{Id:%d FileCount:%d Size:%d Timestamp:%d}", bi.Id, bi.FileCount, bi.Size, bi.Timestamp)
 		})
 
-		expected := usingRockDB + "./" + storageName + "-data> Backup created" + bkp + "> "
+		expected := usingRockDB + "./" + storageName + "-data"
+		expected += "Backup created" + bkp
 		assert.Equal(t, expected, output)
 	})
 


### PR DESCRIPTION
The readline package by default add many keyboard shortcuts
like jump to start of line(ctrl+a), jump to end of line(ctrl+e), etc.

History was added to file "/tmp/faktory.tmp". This is a good option?

Auto-completion via tab is available too. Tab without any text
will show all commands.

I had some problems with my keyboard to test some mappings, I will try will some other keyboard layouts to have sure everything is working as expected. 

I realize that the tests for the cli are a little fragile, I will try to figure out a better way to test it. I just test it on mac, for now, but should work on linux too. 

@mperham please, take a look if this approach is good.