### PR TITLE
Fix the historyFile path

### DIFF
--- a/cmd/faktory-cli/repl.go
+++ b/cmd/faktory-cli/repl.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"os/user"
 	"strconv"
 	"strings"
 	"syscall"
@@ -90,12 +89,9 @@ func repl(path string, store storage.Store) {
 		readline.PcItem("help"),
 	)
 
-	usr, _ := user.Current()
-	dir := usr.HomeDir
-
 	l, err := readline.NewEx(&readline.Config{
 		Prompt:          "> ",
-		HistoryFile:     dir + "/.local/.faktory-cli.history",
+		HistoryFile:     util.HistoryFilePath(),
 		AutoComplete:    completer,
 		InterruptPrompt: "^C",
 		EOFPrompt:       "exit",

--- a/util/util.go
+++ b/util/util.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	mathrand "math/rand"
 	"os"
-	"os/user"
 	"runtime"
 	"time"
 )
@@ -172,28 +171,4 @@ func Backtrace(size int) []string {
 	}
 
 	return str[0:count]
-}
-
-// HistoryFilePath returns the path of the history file
-// $HOME/.local/.faktory-cli.history
-// if the .local folder does not exists, it will create it.
-func HistoryFilePath() string {
-	usr, _ := user.Current()
-	dir := usr.HomeDir + "/.local"
-	historyFilePath := dir + "/.faktory-cli.history"
-
-	exists, err := FileExists(historyFilePath)
-	if err != nil {
-		return ""
-	}
-
-	if !exists {
-		err = os.MkdirAll(dir, 0755)
-		if err != nil {
-			Error("Unable to create $HOME/.local dir", err)
-			return ""
-		}
-	}
-
-	return historyFilePath
 }

--- a/util/util.go
+++ b/util/util.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	mathrand "math/rand"
 	"os"
+	"os/user"
 	"runtime"
 	"time"
 )
@@ -171,4 +172,28 @@ func Backtrace(size int) []string {
 	}
 
 	return str[0:count]
+}
+
+// HistoryFilePath returns the path of the history file
+// $HOME/.local/.faktory-cli.history
+// if the .local folder does not exists, it will create it.
+func HistoryFilePath() string {
+	usr, _ := user.Current()
+	dir := usr.HomeDir + "/.local"
+	historyFilePath := dir + "/.faktory-cli.history"
+
+	exists, err := FileExists(historyFilePath)
+	if err != nil {
+		return ""
+	}
+
+	if !exists {
+		err = os.MkdirAll(dir, 0755)
+		if err != nil {
+			Error("Unable to create $HOME/.local dir", err)
+			return ""
+		}
+	}
+
+	return historyFilePath
 }


### PR DESCRIPTION
The cli will, now, check if the .local folder exists and if not
will create it.

If it's not possible to create the folder, the cli will still works,
but the history will be lost after exit.