### PR TITLE
Switch expired jobs to use retries, fixes #99

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -56,7 +56,7 @@ type Manager interface {
 
 	WorkingCount() int
 
-	ReapLongRunningJobs(timestamp string) (int, error)
+	ReapExpiredJobs(timestamp string) (int, error)
 
 	// Purge deletes all dead jobs
 	Purge() (int64, error)
@@ -66,6 +66,8 @@ type Manager interface {
 
 	// RetryJobs enqueues failed jobs
 	RetryJobs() (int64, error)
+
+	BusyCount(wid string) int
 }
 
 func NewManager(s storage.Store) Manager {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -12,7 +12,15 @@ import (
 	"github.com/contribsys/faktory/util"
 )
 
-const DefaultTimeout = 1800
+const (
+	// Jobs will be reserved for 30 minutes by default.
+	// You can customize this per-job with the reserve_for attribute
+	// in the job payload.
+	DefaultTimeout = 30 * 60
+
+	// Save dead jobs for 180 days, after that they will be purged
+	DeadTTL = 180 * 24 * time.Hour
+)
 
 type Manager interface {
 	Push(job *client.Job) error

--- a/manager/retry.go
+++ b/manager/retry.go
@@ -12,9 +12,6 @@ import (
 	"github.com/contribsys/faktory/util"
 )
 
-// six months
-var deadTTL = 180 * 24 * time.Hour
-
 type FailPayload struct {
 	Jid          string   `json:"jid"`
 	ErrorMessage string   `json:"message"`
@@ -135,7 +132,7 @@ func sendToMorgue(store storage.Store, job *client.Job) error {
 		return err
 	}
 
-	expiry := util.Thens(time.Now().Add(deadTTL))
+	expiry := util.Thens(time.Now().Add(DeadTTL))
 	return store.Dead().AddElement(expiry, job.Jid, bytes)
 }
 

--- a/manager/scheduler.go
+++ b/manager/scheduler.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (m *manager) Purge() (int64, error) {
+	// TODO We need to purge the dead set if it collects more
+	// than N elements.  The dead set shouldn't be able to collect
+	// millions or billions of jobs.  Sidekiq uses a default max size
+	// of 10,000 jobs.
 	dead, err := m.store.Dead().RemoveBefore(util.Nows())
 	if err != nil {
 		return 0, err

--- a/manager/working.go
+++ b/manager/working.go
@@ -30,6 +30,19 @@ func (m *manager) WorkingCount() int {
 	return len(m.workingMap)
 }
 
+func (m *manager) BusyCount(wid string) int {
+	m.workingMutex.RLock()
+
+	count := 0
+	for _, res := range m.workingMap {
+		if res.Wid == wid {
+			count++
+		}
+	}
+	m.workingMutex.RUnlock()
+	return count
+}
+
 /*
  * When we restart the server, we need to load the
  * current set of Reservations back into memory so any
@@ -129,7 +142,7 @@ func (m *manager) Acknowledge(jid string) (*client.Job, error) {
 	return job, nil
 }
 
-func (m *manager) ReapLongRunningJobs(timestamp string) (int, error) {
+func (m *manager) ReapExpiredJobs(timestamp string) (int, error) {
 	elms, err := m.store.Working().RemoveBefore(timestamp)
 	if err != nil {
 		return 0, err

--- a/manager/working.go
+++ b/manager/working.go
@@ -8,6 +8,13 @@ import (
 	"github.com/contribsys/faktory/util"
 )
 
+var (
+	JobReservationExpired = &FailPayload{
+		ErrorType:    "ReservationExpired",
+		ErrorMessage: "Faktory job reservation expired",
+	}
+)
+
 type Reservation struct {
 	Job     *client.Job `json:"job"`
 	Since   string      `json:"reserved_at"`
@@ -122,13 +129,6 @@ func (m *manager) Acknowledge(jid string) (*client.Job, error) {
 	return job, nil
 }
 
-var (
-	JobExecutionExpired = &FailPayload{
-		ErrorType:    "ReservationTimeout",
-		ErrorMessage: "faktory job expired",
-	}
-)
-
 func (m *manager) ReapLongRunningJobs(timestamp string) (int, error) {
 	elms, err := m.store.Working().RemoveBefore(timestamp)
 	if err != nil {
@@ -145,7 +145,7 @@ func (m *manager) ReapLongRunningJobs(timestamp string) (int, error) {
 		}
 
 		job := res.Job
-		err = m.processFailure(job.Jid, JobExecutionExpired)
+		err = m.processFailure(job.Jid, JobReservationExpired)
 		if err != nil {
 			util.Error("Unable to retry reservation", err)
 			continue

--- a/manager/working_test.go
+++ b/manager/working_test.go
@@ -141,11 +141,11 @@ func TestManagerReapLongRunningJobs(t *testing.T) {
 	count, err := m.ReapLongRunningJobs(util.Thens(exp))
 	assert.NoError(t, err)
 	assert.Equal(t, 0, count)
-	assert.EqualValues(t, 0, q.Size())
+	assert.EqualValues(t, 0, store.Retries().Size())
 
 	exp = time.Now().Add(time.Duration(DefaultTimeout+10) * time.Second)
 	count, err = m.ReapLongRunningJobs(util.Thens(exp))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
-	assert.EqualValues(t, 1, q.Size())
+	assert.EqualValues(t, 1, store.Retries().Size())
 }

--- a/server/server.go
+++ b/server/server.go
@@ -43,7 +43,7 @@ type Server struct {
 	Password string
 
 	listener   net.Listener
-	store      storage.Store // FIXME drop store
+	store      storage.Store
 	manager    manager.Manager
 	workers    *workers
 	taskRunner *taskRunner
@@ -91,6 +91,10 @@ func (s *Server) Store() storage.Store {
 	return s.store
 }
 
+func (s *Server) Manager() manager.Manager {
+	return s.manager
+}
+
 func (s *Server) Start() error {
 	store, err := storage.Open("rocksdb", s.Options.StorageDirectory)
 	if err != nil {
@@ -105,7 +109,7 @@ func (s *Server) Start() error {
 	util.Infof("Now listening at %s, press Ctrl-C to stop", s.Options.Binding)
 
 	s.mu.Lock()
-	s.store = store // FIXME drop store
+	s.store = store
 	s.workers = newWorkers()
 	s.manager = manager.NewManager(store)
 	s.listener = listener

--- a/server/tasks.go
+++ b/server/tasks.go
@@ -17,7 +17,7 @@ func (r *reservationReaper) Name() string {
 }
 
 func (r *reservationReaper) Execute() error {
-	count, err := r.m.ReapLongRunningJobs(util.Nows())
+	count, err := r.m.ReapExpiredJobs(util.Nows())
 	if err != nil {
 		return err
 	}

--- a/server/workers.go
+++ b/server/workers.go
@@ -15,7 +15,7 @@ import (
 // A client can be a producer AND/OR consumer of jobs.  Typically a process will
 // either only produce jobs (like a webapp pushing jobs) or produce/consume jobs
 // (like a faktory worker process where a job can create other jobs while
-// executing another job).
+// executing).
 //
 // Each Faktory worker process should send a BEAT command every 15 seconds.
 // Only consumers should send a BEAT.  If Faktory does not receive a BEAT from a
@@ -23,7 +23,7 @@ import (
 // page.
 //
 // From Faktory's POV, the worker can BEAT again and resume normal operations,
-// e.g.  due to a network partition.  If a process dies, it will be removed
+// e.g. due to a network partition.  If a process dies, it will be removed
 // after 1 minute and its jobs recovered after the job reservation timeout has
 // passed (typically 30 minutes).
 //
@@ -119,21 +119,6 @@ func (worker *ClientData) Signal(newstate WorkerState) {
 
 func (worker *ClientData) IsConsumer() bool {
 	return worker.Wid != ""
-}
-
-func (worker *ClientData) BusyCount() int {
-	// FIXME workingMutex
-	// workingMutex.Lock()
-	// defer workingMutex.Unlock()
-
-	count := 0
-	// FIXME busycount
-	// for _, res := range workingMap {
-	// 	if res.Wid == worker.Wid {
-	// 		count++
-	// 	}
-	// }
-	return count
 }
 
 type workers struct {

--- a/server/workers_test.go
+++ b/server/workers_test.go
@@ -44,8 +44,6 @@ func TestClientData(t *testing.T) {
 	cw.Signal(Quiet)
 	assert.Equal(t, Terminate, cw.state)
 	assert.True(t, cw.IsQuiet())
-
-	assert.Equal(t, 0, cw.BusyCount())
 }
 
 func TestWorkers(t *testing.T) {

--- a/webui/busy.ego
+++ b/webui/busy.ego
@@ -54,7 +54,7 @@ func ego_busy(w io.Writer, req *http.Request) {
           <% } %>
         </td>
         <td><%= Timeago(worker.StartedAt) %></td>
-        <td><%= worker.BusyCount() %></td>
+        <td><%= defaultServer.Manager().BusyCount(worker.Wid) %></td>
         <td>
           <div class="btn-group pull-right flip">
             <form method="POST">


### PR DESCRIPTION
Expired jobs can be poison pills, killing their worker process.  Instead of re-enqueueing them forever, have them use the retry process so that they backoff properly and will eventually be marked as dead.