### PR TITLE
Added Vagrantfile and setup.sh for Debian Stretch (stable)

### DIFF
--- a/build/debian/Vagrantfile
+++ b/build/debian/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/stretch64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # When you run Faktory within the box, the API and web ports will be
+  # available at 17419 and 17420 on the host OS.
+  config.vm.network "forwarded_port", guest: 7419, host: 17419, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 7420, host: 17420, host_ip: "127.0.0.1"
+
+  # If this shared folder fails, you likely need to install the Vagrant
+  # guest extensions, install this plugin to do so:
+  #
+  #   vagrant plugin install vagrant-vbguest
+  config.vm.synced_folder "../..", "/faktory"
+
+  # Need a bit of extra memory to build.
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
+  end
+end

--- a/build/debian/setup.sh
+++ b/build/debian/setup.sh
@@ -1,0 +1,50 @@
+set -e
+cd $HOME
+
+echo === Installing necessary system libraries to build RocksDB
+sudo apt-get update -y
+sudo apt install -y --no-install-recommends make g++ curl
+
+echo === Building RocksDB
+# download and compile rocksdb
+if [ ! -f ~/rocksdb/librocksdb.a ]; then
+  git clone https://github.com/facebook/rocksdb
+  cd rocksdb
+  git checkout v5.9.2
+  time PORTABLE=1 make static_lib
+  # default binary is 340MB!
+  # stripped is 18MB
+  strip -g librocksdb.a
+fi
+
+echo === Installing Golang
+# download and install go 1.9
+if [ ! -d /usr/local/go ]; then
+  cd /usr/local
+  curl https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz | sudo tar xfz -
+  echo "export PATH=/usr/local/go/bin:$HOME/go/bin:\$PATH" >> ~/.bash_profile
+  echo "export GOPATH=~/go" >> ~/.bash_profile
+  export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH
+fi
+
+export GOPATH=~/go
+
+
+mkdir -p ~/go/src/github.com/contribsys
+cd ~/go/src/github.com/contribsys && ln -s /faktory faktory && cd faktory
+
+# download project dependencies
+export ROCKSDB_HOME="$HOME/rocksdb"
+export CGO_CFLAGS="-I${ROCKSDB_HOME}/include"
+export CGO_LDFLAGS="-L${ROCKSDB_HOME}"
+echo === Installing dependencies
+make prepare
+
+echo === Running Faktory test suite
+make test
+make build
+
+# If you wish to build a .deb package, run these commands
+sudo apt install ruby-dev --no-install-recommends -y
+sudo gem install -N fpm
+make deb


### PR DESCRIPTION
Not sure if you want this, but I did so here it is.

It might be a little flaky still, I had a heck of a time getting everything juuuuust right.  I will probably be trying to streamline it a bit.

It also needs a bit more memory in the VM than the default 512 mb to build and gets this by assuming the libvirt Vagrant provider.  This may be a slightly odd assumption but I'm not a vagrant pro so I honestly don't know of a more portable way of doing it.