### PR TITLE
add a `FAKTORY_SKIP_TLS_VERIFY` environment variable

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -144,7 +144,14 @@ func Dial(srv *Server, password string) (*Client, error) {
 	var conn net.Conn
 	dial := &net.Dialer{Timeout: srv.Timeout}
 	if srv.Network == "tcp+tls" {
-		conn, err = tls.DialWithDialer(dial, "tcp", srv.Address, &tls.Config{})
+		insecure := false
+		v, ok := os.LookupEnv("FAKTORY_SKIP_TLS_VERIFY")
+		if ok && strings.ToLower(v) == "yes"{
+			insecure = true
+		}
+		conn, err = tls.DialWithDialer(dial, "tcp", srv.Address, &tls.Config{
+			InsecureSkipVerify: insecure,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -146,7 +146,7 @@ func Dial(srv *Server, password string) (*Client, error) {
 	if srv.Network == "tcp+tls" {
 		insecure := false
 		v, ok := os.LookupEnv("FAKTORY_SKIP_TLS_VERIFY")
-		if ok && strings.ToLower(v) == "yes"{
+		if ok && strings.ToLower(v) == "yes" {
 			insecure = true
 		}
 		conn, err = tls.DialWithDialer(dial, "tcp", srv.Address, &tls.Config{


### PR DESCRIPTION
There currently isn't a way for the client to skip TLS verification

PR adds a `FAKTORY_SKIP_TLS_VERIFY` environment variable that needs to match "yes" to disable hostname / certificate verification checks 