### PR TITLE
Add periodic task to reset size cache if necessary

### DIFF
--- a/server/task_runner.go
+++ b/server/task_runner.go
@@ -52,8 +52,8 @@ func (ts *taskRunner) AddTask(sec int64, thing taskable) {
 	tsk.runner = thing
 	tsk.every = sec
 	ts.mutex.Lock()
-	defer ts.mutex.Unlock()
 	ts.tasks = append(ts.tasks, &tsk)
+	ts.mutex.Unlock()
 }
 
 func (ts *taskRunner) Run(waiter *sync.WaitGroup) {
@@ -134,6 +134,8 @@ func (s *Server) startTasks(waiter *sync.WaitGroup) {
 	// backup runner
 	policy := newBackupPolicy(s)
 	ts.AddTask(policy.Frequency(), policy)
+
+	ts.AddTask(60, &cacheReset{s.store, 0})
 
 	ts.Run(waiter)
 	s.taskRunner = ts

--- a/server/tasks.go
+++ b/server/tasks.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/contribsys/faktory/manager"
+	"github.com/contribsys/faktory/storage"
 	"github.com/contribsys/faktory/util"
 )
 
@@ -54,5 +55,28 @@ func (r *beatReaper) Stats() map[string]interface{} {
 	return map[string]interface{}{
 		"size":   r.w.Count(),
 		"reaped": r.count,
+	}
+}
+
+type cacheReset struct {
+	s     storage.Store
+	count int
+}
+
+func (r *cacheReset) Name() string {
+	return "Storage Cache"
+}
+
+func (r *cacheReset) Execute() error {
+	r.count += r.s.Retries().Reset()
+	r.count += r.s.Scheduled().Reset()
+	r.count += r.s.Working().Reset()
+	r.count += r.s.Dead().Reset()
+	return nil
+}
+
+func (r *cacheReset) Stats() map[string]interface{} {
+	return map[string]interface{}{
+		"resetCount": r.count,
 	}
 }

--- a/storage/queue_rocksdb.go
+++ b/storage/queue_rocksdb.go
@@ -21,7 +21,7 @@ var (
 	// This is known as "back pressue" and is important to
 	// prevent bugs in one component from taking down the
 	// entire system.
-	DefaultMaxSize = uint64(1000000)
+	DefaultMaxSize = uint64(10000000)
 )
 
 const (

--- a/storage/sorted_rocksdb.go
+++ b/storage/sorted_rocksdb.go
@@ -113,7 +113,7 @@ func (ts *rocksSortedSet) init() *rocksSortedSet {
 }
 
 const (
-	MAX uint64 = 2<<63 - 1
+	MAX uint64 = 2 << 62
 )
 
 func (ts *rocksSortedSet) Reset() int {

--- a/storage/types.go
+++ b/storage/types.go
@@ -64,6 +64,7 @@ type SortedSet interface {
 	Name() string
 	Size() uint64
 	Clear() (uint64, error)
+	Reset() int
 
 	AddElement(timestamp string, jid string, payload []byte) error
 


### PR DESCRIPTION
Workaround for #148.  Because the size value is cached, it can get out of sync with the data actually in RocksDB.  We check to see if we need to reset the value once per minute.