### PR TITLE
Split up storage implementation so we can implement multiple backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: clean generate ## Execute test suite
 		github.com/contribsys/faktory/client \
 		github.com/contribsys/faktory/manager \
 		github.com/contribsys/faktory/server \
-		github.com/contribsys/faktory/storage \
+		github.com/contribsys/faktory/storage/rocksdb \
 		github.com/contribsys/faktory/test \
 		github.com/contribsys/faktory/util \
 		github.com/contribsys/faktory/webui \

--- a/cmd/faktory-cli/repl.go
+++ b/cmd/faktory-cli/repl.go
@@ -16,6 +16,8 @@ import (
 	"github.com/contribsys/faktory/cli"
 	"github.com/contribsys/faktory/client"
 	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/rocksdb"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 	"github.com/contribsys/gorocksdb"
 )
@@ -76,7 +78,7 @@ func main() {
 	}
 }
 
-func repl(path string, store storage.Store) {
+func repl(path string, store types.Store) {
 	fmt.Printf("Faktory %s, using RocksDB %s at %s\n", client.Version, gorocksdb.RocksDBVersion(), path)
 
 	var completer = readline.NewPrefixCompleter(
@@ -129,7 +131,7 @@ func repl(path string, store storage.Store) {
 	}
 }
 
-func execute(cmd []string, store storage.Store, path string) error {
+func execute(cmd []string, store types.Store, path string) error {
 	first := cmd[0]
 	switch first {
 	case "exit":
@@ -156,7 +158,7 @@ func execute(cmd []string, store storage.Store, path string) error {
 	return nil
 }
 
-func flush(store storage.Store) error {
+func flush(store types.Store) error {
 	if err := store.Flush(); err != nil {
 		return err
 	}
@@ -164,22 +166,22 @@ func flush(store storage.Store) error {
 	return nil
 }
 
-func backup(store storage.Store) error {
+func backup(store types.Store) error {
 	if err := store.Backup(); err != nil {
 		return err
 	}
 	fmt.Println("Backup created")
-	store.EachBackup(func(x storage.BackupInfo) {
+	store.EachBackup(func(x types.BackupInfo) {
 		fmt.Printf("%+v\n", x)
 	})
 	return nil
 }
 
-func repair(store storage.Store, path string) error {
+func repair(store types.Store, path string) error {
 	if store != nil {
 		store.Close()
 	}
-	opts := storage.DefaultOptions()
+	opts := rocksdb.DefaultOptions()
 	if err := gorocksdb.RepairDb(path, opts); err != nil {
 		return err
 	}
@@ -189,8 +191,8 @@ func repair(store storage.Store, path string) error {
 	return nil
 }
 
-func purge(store storage.Store, args []string) error {
-	count := storage.DefaultKeepBackupsCount
+func purge(store types.Store, args []string) error {
+	count := types.DefaultKeepBackupsCount
 	if len(args) == 1 {
 		val, err := strconv.Atoi(args[0])
 		if err != nil {
@@ -205,7 +207,7 @@ func purge(store storage.Store, args []string) error {
 	return nil
 }
 
-func restore(store storage.Store) error {
+func restore(store types.Store) error {
 	if err := store.RestoreFromLatest(); err != nil {
 		return err
 	}

--- a/cmd/faktory-cli/repl_test.go
+++ b/cmd/faktory-cli/repl_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/contribsys/faktory/client"
 	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/gorocksdb"
 	"github.com/stretchr/testify/assert"
 )
@@ -117,7 +118,7 @@ func TestInteractiveOutputs(t *testing.T) {
 		assert.NoError(t, err)
 
 		bkp := ""
-		db.EachBackup(func(bi storage.BackupInfo) {
+		db.EachBackup(func(bi types.BackupInfo) {
 			bkp = fmt.Sprintf("{Id:%d FileCount:%d Size:%d Timestamp:%d}", bi.Id, bi.FileCount, bi.Size, bi.Timestamp)
 		})
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/contribsys/faktory/client"
-	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 )
 
@@ -70,7 +70,7 @@ type Manager interface {
 	BusyCount(wid string) int
 }
 
-func NewManager(s storage.Store) Manager {
+func NewManager(s types.Store) Manager {
 	m := &manager{
 		store:      s,
 		workingMap: map[string]*Reservation{},
@@ -80,7 +80,7 @@ func NewManager(s storage.Store) Manager {
 }
 
 type manager struct {
-	store storage.Store
+	store types.Store
 
 	// Hold the working set in memory so we don't need to burn CPU
 	// marshalling between Rocks and memory when doing 1000s of jobs/sec.
@@ -160,7 +160,7 @@ func (m *manager) enqueue(job *client.Job) error {
 }
 
 func (m *manager) Fetch(ctx context.Context, wid string, queues ...string) (*client.Job, error) {
-	var first storage.Queue
+	var first types.Queue
 
 	for idx, qname := range queues {
 		q, err := m.store.GetQueue(qname)

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/contribsys/faktory/client"
 	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -324,7 +325,7 @@ func TestManagerFetch(t *testing.T) {
 	})
 }
 
-func setupTest(t *testing.T) (storage.Store, func(t *testing.T)) {
+func setupTest(t *testing.T) (types.Store, func(t *testing.T)) {
 	path := fmt.Sprintf("/tmp/%s.db", t.Name())
 	store, err := storage.Open("rocksdb", path)
 	if err != nil {

--- a/manager/retry.go
+++ b/manager/retry.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/contribsys/faktory/client"
-	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 )
 
@@ -115,7 +115,7 @@ func (m *manager) processFailure(jid string, failure *FailPayload) error {
 	return sendToMorgue(m.store, job)
 }
 
-func retryLater(store storage.Store, job *client.Job) error {
+func retryLater(store types.Store, job *client.Job) error {
 	when := util.Thens(nextRetry(job))
 	job.Failure.NextAt = when
 	bytes, err := json.Marshal(job)
@@ -126,7 +126,7 @@ func retryLater(store storage.Store, job *client.Job) error {
 	return store.Retries().AddElement(when, job.Jid, bytes)
 }
 
-func sendToMorgue(store storage.Store, job *client.Job) error {
+func sendToMorgue(store types.Store, job *client.Job) error {
 	bytes, err := json.Marshal(job)
 	if err != nil {
 		return err

--- a/manager/scheduler.go
+++ b/manager/scheduler.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/contribsys/faktory/client"
-	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 )
 
@@ -28,7 +28,7 @@ func (m *manager) RetryJobs() (int64, error) {
 	return m.schedule(m.store.Retries())
 }
 
-func (m *manager) schedule(set storage.SortedSet) (int64, error) {
+func (m *manager) schedule(set types.SortedSet) (int64, error) {
 	elms, err := set.RemoveBefore(util.Nows())
 	if err != nil {
 		return 0, err

--- a/manager/scheduler_test.go
+++ b/manager/scheduler_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/contribsys/faktory/client"
-	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -136,7 +136,7 @@ func TestRetryJobs(t *testing.T) {
 	assert.EqualValues(t, 0, store.Retries().Size())
 }
 
-func addJob(t *testing.T, set storage.SortedSet, timestamp string, job *client.Job) {
+func addJob(t *testing.T, set types.SortedSet, timestamp string, job *client.Job) {
 	data, err := json.Marshal(job)
 	assert.NoError(t, err)
 

--- a/server/backup.go
+++ b/server/backup.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 )
 
@@ -53,7 +53,7 @@ func (bp *backupPolicy) Execute() error {
 		util.Error("BACKUP FAILED", err)
 		return err
 	}
-	err = bp.Server.Store().PurgeOldBackups(storage.DefaultKeepBackupsCount)
+	err = bp.Server.Store().PurgeOldBackups(types.DefaultKeepBackupsCount)
 	if err != nil {
 		util.Error("PURGE FAILED", err)
 		return err

--- a/server/scanner.go
+++ b/server/scanner.go
@@ -4,7 +4,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 )
 
@@ -13,7 +13,7 @@ type scannerTask func() (int64, error)
 type scanner struct {
 	name     string
 	task     scannerTask
-	set      storage.SortedSet
+	set      types.SortedSet
 	jobs     int64
 	cycles   int64
 	walltime int64

--- a/server/server.go
+++ b/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/contribsys/faktory/client"
 	"github.com/contribsys/faktory/manager"
 	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 )
 
@@ -44,7 +45,7 @@ type Server struct {
 	Password string
 
 	listener   net.Listener
-	store      storage.Store
+	store      types.Store
 	manager    manager.Manager
 	workers    *workers
 	taskRunner *taskRunner
@@ -87,7 +88,7 @@ func (s *Server) Heartbeats() map[string]*ClientData {
 	return s.workers.heartbeats
 }
 
-func (s *Server) Store() storage.Store {
+func (s *Server) Store() types.Store {
 	return s.store
 }
 
@@ -317,7 +318,7 @@ func (s *Server) CurrentState() (map[string]interface{}, error) {
 	totalQueued := 0
 	totalQueues := 0
 	// queue size is cached so this should be very efficient.
-	s.store.EachQueue(func(q storage.Queue) {
+	s.store.EachQueue(func(q types.Queue) {
 		totalQueued += int(q.Size())
 		totalQueues++
 	})

--- a/server/tasks.go
+++ b/server/tasks.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/contribsys/faktory/manager"
-	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 )
 
@@ -59,7 +59,7 @@ func (r *beatReaper) Stats() map[string]interface{} {
 }
 
 type cacheReset struct {
-	s     storage.Store
+	s     types.Store
 	count int
 }
 

--- a/storage/rocksdb/backup.go
+++ b/storage/rocksdb/backup.go
@@ -1,17 +1,11 @@
-package storage
+package rocksdb
 
 import (
 	"fmt"
 
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 	"github.com/contribsys/gorocksdb"
-)
-
-const (
-	// Assume hourly backups and keep a day's worth.
-	// If we take backups every 5 minutes, this will keep
-	// two hours worth.
-	DefaultKeepBackupsCount int = 24
 )
 
 func (store *rocksStore) PurgeOldBackups(keepCount int) error {
@@ -42,7 +36,7 @@ func (store *rocksStore) Backup() error {
 	return be.CreateNewBackup(store.db)
 }
 
-func (store *rocksStore) EachBackup(fn func(BackupInfo)) error {
+func (store *rocksStore) EachBackup(fn func(types.BackupInfo)) error {
 	be, err := gorocksdb.OpenBackupEngine(store.opts, store.db.Name())
 	if err != nil {
 		return err
@@ -52,7 +46,7 @@ func (store *rocksStore) EachBackup(fn func(BackupInfo)) error {
 	defer bei.Destroy()
 
 	for i := 0; i < bei.GetCount(); i++ {
-		fn(BackupInfo{
+		fn(types.BackupInfo{
 			Id:        bei.GetBackupId(i),
 			FileCount: bei.GetNumFiles(i),
 			Size:      bei.GetSize(i),

--- a/storage/rocksdb/backup_test.go
+++ b/storage/rocksdb/backup_test.go
@@ -1,9 +1,10 @@
-package storage
+package rocksdb
 
 import (
 	"os"
 	"testing"
 
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,7 +14,7 @@ func TestBackupAndRestore(t *testing.T) {
 
 	defer os.RemoveAll("/tmp/backup.db")
 	// open db
-	db, err := Open("rocksdb", "/tmp/backup.db")
+	db, err := OpenRocks("/tmp/backup.db")
 	assert.NoError(t, err)
 
 	// put elements
@@ -28,7 +29,7 @@ func TestBackupAndRestore(t *testing.T) {
 	assert.EqualValues(t, 1, rs.Size())
 
 	count := 0
-	db.EachBackup(func(element BackupInfo) {
+	db.EachBackup(func(element types.BackupInfo) {
 		count++
 	})
 	assert.Equal(t, 0, count)
@@ -37,7 +38,7 @@ func TestBackupAndRestore(t *testing.T) {
 	err = db.Backup()
 	assert.NoError(t, err)
 	count = 0
-	db.EachBackup(func(element BackupInfo) {
+	db.EachBackup(func(element types.BackupInfo) {
 		count++
 	})
 	assert.Equal(t, 1, count)
@@ -50,7 +51,7 @@ func TestBackupAndRestore(t *testing.T) {
 	err = db.RestoreFromLatest()
 	assert.NoError(t, err)
 
-	db, err = Open("rocksdb", "/tmp/backup.db")
+	db, err = OpenRocks("/tmp/backup.db")
 	assert.NoError(t, err)
 
 	// verify elements
@@ -90,7 +91,7 @@ func TestBackupAndRestore(t *testing.T) {
 	err = db.RestoreFromLatest()
 	assert.NoError(t, err)
 
-	db, err = Open("rocksdb", "/tmp/backup.db")
+	db, err = OpenRocks("/tmp/backup.db")
 	assert.NoError(t, err)
 
 	q, err = db.GetQueue("default")

--- a/storage/rocksdb/history.go
+++ b/storage/rocksdb/history.go
@@ -1,4 +1,4 @@
-package storage
+package rocksdb
 
 import (
 	"encoding/binary"

--- a/storage/rocksdb/history_test.go
+++ b/storage/rocksdb/history_test.go
@@ -1,4 +1,4 @@
-package storage
+package rocksdb
 
 import (
 	"encoding/binary"
@@ -14,7 +14,7 @@ func TestStatsMerge(t *testing.T) {
 	t.Parallel()
 
 	defer os.RemoveAll("/tmp/merge.db")
-	db, err := Open("rocksdb", "/tmp/merge.db")
+	db, err := OpenRocks("/tmp/merge.db")
 	assert.NoError(t, err)
 
 	store := db.(*rocksStore)
@@ -45,7 +45,7 @@ func TestStatsMerge(t *testing.T) {
 	store.Success()
 	db.Close()
 
-	db, err = Open("rocksdb", "/tmp/merge.db")
+	db, err = OpenRocks("/tmp/merge.db")
 	assert.NoError(t, err)
 	defer db.Close()
 

--- a/storage/rocksdb/queue_rocksdb.go
+++ b/storage/rocksdb/queue_rocksdb.go
@@ -1,4 +1,4 @@
-package storage
+package rocksdb
 
 import (
 	"container/list"

--- a/storage/rocksdb/queue_test.go
+++ b/storage/rocksdb/queue_test.go
@@ -1,4 +1,4 @@
-package storage
+package rocksdb
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +17,7 @@ func TestBasicQueueOps(t *testing.T) {
 	t.Parallel()
 	defer os.RemoveAll("/tmp/queues.db")
 
-	store, err := Open("rocksdb", "/tmp/queues.db")
+	store, err := OpenRocks("/tmp/queues.db")
 	assert.NoError(t, err)
 	defer store.Close()
 	q, err := store.GetQueue("default")
@@ -81,7 +82,7 @@ func TestBasicQueueOps(t *testing.T) {
 func TestQueuePrioritization(t *testing.T) {
 	os.RemoveAll("/tmp/qpriority.db")
 	defer os.RemoveAll("/tmp/qpriority.db")
-	store, err := Open("rocksdb", "/tmp/qpriority.db")
+	store, err := OpenRocks("/tmp/qpriority.db")
 	assert.NoError(t, err)
 	q, err := store.GetQueue("default")
 	assert.NoError(t, err)
@@ -175,7 +176,7 @@ func TestDecentQueueUsage(t *testing.T) {
 	t.Parallel()
 
 	defer os.RemoveAll("/tmp/qbench.db")
-	store, err := Open("rocksdb", "/tmp/qbench.db")
+	store, err := OpenRocks("/tmp/qbench.db")
 	assert.NoError(t, err)
 	q, err := store.GetQueue("default")
 	assert.NoError(t, err)
@@ -200,7 +201,7 @@ func TestDecentQueueUsage(t *testing.T) {
 	// Close DB, reopen
 	store.Close()
 
-	store, err = Open("rocksdb", "/tmp/qbench.db")
+	store, err = OpenRocks("/tmp/qbench.db")
 	assert.NoError(t, err)
 
 	q, err = store.GetQueue("default")
@@ -230,7 +231,7 @@ func TestDecentQueueUsage(t *testing.T) {
 func TestThreadedQueueUsage(t *testing.T) {
 	t.Parallel()
 	defer os.RemoveAll("/tmp/qthreaded.db")
-	store, err := Open("rocksdb", "/tmp/qthreaded.db")
+	store, err := OpenRocks("/tmp/qthreaded.db")
 	assert.NoError(t, err)
 	q, err := store.GetQueue("default")
 	assert.NoError(t, err)
@@ -264,7 +265,7 @@ var (
 	counter int64
 )
 
-func pushAndPop(t *testing.T, n int, q Queue) {
+func pushAndPop(t *testing.T, n int, q types.Queue) {
 	for i := 0; i < n; i++ {
 		_, data := fakeJob()
 		err := q.Push(5, data)
@@ -309,7 +310,7 @@ func TestQueueKeys(t *testing.T) {
 
 func TestClearAndPush(t *testing.T) {
 	defer os.RemoveAll("/tmp/qpush.db")
-	store, err := Open("rocksdb", "/tmp/qpush.db")
+	store, err := OpenRocks("/tmp/qpush.db")
 	assert.NoError(t, err)
 	q, err := store.GetQueue("lksjadfl")
 	assert.NoError(t, err)
@@ -329,7 +330,7 @@ func TestClearAndPush(t *testing.T) {
 
 func BenchmarkQueuePerformance(b *testing.B) {
 	defer os.RemoveAll("/tmp/qblah.db")
-	store, err := Open("rocksdb", "/tmp/qblah.db")
+	store, err := OpenRocks("/tmp/qblah.db")
 	assert.NoError(b, err)
 	assert.NotNil(b, store)
 	defer store.Close()
@@ -352,7 +353,7 @@ func TestReopening(t *testing.T) {
 	t.Parallel()
 
 	defer os.RemoveAll("/tmp/reopening.db")
-	store, err := Open("rocksdb", "/tmp/reopening.db")
+	store, err := OpenRocks("/tmp/reopening.db")
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
 
@@ -388,7 +389,7 @@ func TestReopening(t *testing.T) {
 
 	store.Close()
 
-	store, err = Open("rocksdb", "/tmp/reopening.db")
+	store, err = OpenRocks("/tmp/reopening.db")
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
 
@@ -403,7 +404,7 @@ func TestReopening(t *testing.T) {
 	a, err = store.GetQueue("another")
 	assert.NoError(t, err)
 
-	store.EachQueue(func(q Queue) {
+	store.EachQueue(func(q types.Queue) {
 		fmt.Println(q.Name(), q.Size())
 	})
 
@@ -452,7 +453,7 @@ func TestReopening(t *testing.T) {
 
 func TestBlockingPop(t *testing.T) {
 	defer os.RemoveAll("/tmp/blocking.db")
-	store, err := Open("rocksdb", "/tmp/blocking.db")
+	store, err := OpenRocks("/tmp/blocking.db")
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
 	defer store.Close()

--- a/storage/rocksdb/rocksdb.go
+++ b/storage/rocksdb/rocksdb.go
@@ -1,4 +1,4 @@
-package storage
+package rocksdb
 
 import (
 	"encoding/binary"
@@ -11,6 +11,7 @@ import (
 	"regexp"
 
 	"github.com/contribsys/faktory/storage/brodal"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 	"github.com/contribsys/gorocksdb"
 )
@@ -53,7 +54,7 @@ func DefaultOptions() *gorocksdb.Options {
 
 var registerMutex sync.Mutex
 
-func OpenRocks(path string) (Store, error) {
+func OpenRocks(path string) (types.Store, error) {
 
 	util.Infof("Initializing storage at %s", path)
 	util.Debugf("Using RocksDB v%s", gorocksdb.RocksDBVersion())
@@ -120,7 +121,7 @@ func (store *rocksStore) Failures() uint64 {
 }
 
 // queues are iterated in sorted, lexigraphical order
-func (store *rocksStore) EachQueue(x func(Queue)) {
+func (store *rocksStore) EachQueue(x func(types.Queue)) {
 	store.mu.Lock()
 	keys := make([]string, 0, len(store.queueSet))
 	for k := range store.queueSet {
@@ -237,7 +238,7 @@ var (
 	ValidQueueName = regexp.MustCompile(`\A[a-zA-Z0-9._-]+\z`)
 )
 
-func (store *rocksStore) GetQueue(name string) (Queue, error) {
+func (store *rocksStore) GetQueue(name string) (types.Queue, error) {
 	if name == "" {
 		return nil, fmt.Errorf("queue name cannot be blank")
 	}
@@ -291,18 +292,18 @@ func (store *rocksStore) Close() error {
 	return nil
 }
 
-func (store *rocksStore) Retries() SortedSet {
+func (store *rocksStore) Retries() types.SortedSet {
 	return store.retries
 }
 
-func (store *rocksStore) Scheduled() SortedSet {
+func (store *rocksStore) Scheduled() types.SortedSet {
 	return store.scheduled
 }
 
-func (store *rocksStore) Working() SortedSet {
+func (store *rocksStore) Working() types.SortedSet {
 	return store.working
 }
 
-func (store *rocksStore) Dead() SortedSet {
+func (store *rocksStore) Dead() types.SortedSet {
 	return store.dead
 }

--- a/storage/rocksdb/sorted_rocksdb.go
+++ b/storage/rocksdb/sorted_rocksdb.go
@@ -1,9 +1,10 @@
-package storage
+package rocksdb
 
 import (
 	"fmt"
 	"sync/atomic"
 
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/gorocksdb"
 )
 
@@ -188,7 +189,7 @@ func (ts *rocksSortedSet) RemoveBefore(tstamp string) ([][]byte, error) {
 	return results, nil
 }
 
-func (ts *rocksSortedSet) MoveTo(ots SortedSet, tstamp string, jid string, mutator func(value []byte) (string, []byte, error)) error {
+func (ts *rocksSortedSet) MoveTo(ots types.SortedSet, tstamp string, jid string, mutator func(value []byte) (string, []byte, error)) error {
 	other := ots.(*rocksSortedSet)
 	key := []byte(fmt.Sprintf("%s|%s", tstamp, jid))
 

--- a/storage/rocksdb/sorted_test.go
+++ b/storage/rocksdb/sorted_test.go
@@ -1,4 +1,4 @@
-package storage
+package rocksdb
 
 import (
 	"fmt"
@@ -15,7 +15,7 @@ func TestBasicSortedSet(t *testing.T) {
 	t.Parallel()
 
 	defer os.RemoveAll("/tmp/sorted.db")
-	db, err := Open("rocksdb", "/tmp/sorted.db")
+	db, err := OpenRocks("/tmp/sorted.db")
 	assert.NoError(t, err)
 	defer db.Close()
 
@@ -65,7 +65,7 @@ func TestRocksSortedSet(b *testing.T) {
 	b.Parallel()
 	defer os.RemoveAll("/tmp/rocks.db")
 
-	db, err := Open("rocksdb", "/tmp/rocks.db")
+	db, err := OpenRocks("/tmp/rocks.db")
 	assert.NoError(b, err)
 	defer db.Close()
 

--- a/storage/rocksdb/transactions.go
+++ b/storage/rocksdb/transactions.go
@@ -1,10 +1,11 @@
-package storage
+package rocksdb
 
 import (
 	"encoding/json"
 	"sync/atomic"
 
 	"github.com/contribsys/faktory/client"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/gorocksdb"
 )
 
@@ -23,13 +24,13 @@ func (store *rocksStore) newTransaction() *Transaction {
 
 // Enqueue all moves all jobs within the given set into the
 // queues associated with those jobs.
-func (store *rocksStore) EnqueueAll(set SortedSet) error {
+func (store *rocksStore) EnqueueAll(set types.SortedSet) error {
 	return set.Each(func(idx int, key []byte, data []byte) error {
 		return store.EnqueueFrom(set, key)
 	})
 }
 
-func (store *rocksStore) EnqueueFrom(set SortedSet, key []byte) error {
+func (store *rocksStore) EnqueueFrom(set types.SortedSet, key []byte) error {
 	return store.RunTransaction(func(xa *Transaction) error {
 		ss := set.(*rocksSortedSet)
 

--- a/storage/rocksdb/transactions_test.go
+++ b/storage/rocksdb/transactions_test.go
@@ -1,4 +1,4 @@
-package storage
+package rocksdb
 
 import (
 	"os"
@@ -13,7 +13,7 @@ func TestEnqueueAll(t *testing.T) {
 	t.Parallel()
 
 	defer os.RemoveAll("/tmp/xa.db")
-	db, err := Open("rocksdb", "/tmp/xa.db")
+	db, err := OpenRocks("/tmp/xa.db")
 	assert.NoError(t, err)
 	defer db.Close()
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,0 +1,16 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/contribsys/faktory/storage/rocksdb"
+	"github.com/contribsys/faktory/storage/types"
+)
+
+func Open(dbtype string, path string) (types.Store, error) {
+	if dbtype == "rocksdb" {
+		return rocksdb.OpenRocks(path)
+	} else {
+		return nil, fmt.Errorf("Invalid dbtype: %s", dbtype)
+	}
+}

--- a/storage/types/types.go
+++ b/storage/types/types.go
@@ -1,8 +1,12 @@
-package storage
+package types
 
-import (
-	"context"
-	"fmt"
+import "context"
+
+const (
+	// Assume hourly backups and keep a day's worth.
+	// If we take backups every 5 minutes, this will keep
+	// two hours worth.
+	DefaultKeepBackupsCount int = 24
 )
 
 type BackupInfo struct {
@@ -80,12 +84,4 @@ type SortedSet interface {
 	// SortedSet atomically.  The given func may mutate the payload and
 	// return a new tstamp.
 	MoveTo(SortedSet, string, string, func([]byte) (string, []byte, error)) error
-}
-
-func Open(dbtype string, path string) (Store, error) {
-	if dbtype == "rocksdb" {
-		return OpenRocks(path)
-	} else {
-		return nil, fmt.Errorf("Invalid dbtype: %s", dbtype)
-	}
 }

--- a/webui/debug.ego
+++ b/webui/debug.ego
@@ -7,7 +7,7 @@ import (
   "time"
 
   "github.com/contribsys/faktory/client"
-  "github.com/contribsys/faktory/storage"
+  "github.com/contribsys/faktory/storage/types"
   "github.com/contribsys/gorocksdb"
 )
 
@@ -83,7 +83,7 @@ func ego_debug(w io.Writer, req *http.Request) {
         </tr>
       </thead>
       <tbody>
-        <% err := defaultServer.Store().EachBackup(func(bi storage.BackupInfo) { %>
+        <% err := defaultServer.Store().EachBackup(func(bi types.BackupInfo) { %>
         <tr>
           <td><%= bi.Id %></td>
           <td><%= bi.FileCount %></td>

--- a/webui/helpers.go
+++ b/webui/helpers.go
@@ -14,7 +14,7 @@ import (
 	"github.com/contribsys/faktory/client"
 	"github.com/contribsys/faktory/manager"
 	"github.com/contribsys/faktory/server"
-	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/storage/types"
 	"github.com/contribsys/faktory/util"
 	"github.com/justinas/nosurf"
 )
@@ -66,13 +66,13 @@ type Queue struct {
 
 func queues() []Queue {
 	queues := make([]Queue, 0)
-	defaultServer.Store().EachQueue(func(q storage.Queue) {
+	defaultServer.Store().EachQueue(func(q types.Queue) {
 		queues = append(queues, Queue{q.Name(), q.Size()})
 	})
 	return queues
 }
 
-func store() storage.Store {
+func store() types.Store {
 	return defaultServer.Store()
 }
 
@@ -103,7 +103,7 @@ func uintWithDelimiter(val uint64) string {
 	}
 }
 
-func queueJobs(q storage.Queue, count, currentPage uint64, fn func(idx int, key []byte, job *client.Job)) {
+func queueJobs(q types.Queue, count, currentPage uint64, fn func(idx int, key []byte, job *client.Job)) {
 	err := q.Page(int64((currentPage-1)*count), int64(count), func(idx int, key, data []byte) error {
 		var job client.Job
 		err := json.Unmarshal(data, &job)
@@ -121,7 +121,7 @@ func queueJobs(q storage.Queue, count, currentPage uint64, fn func(idx int, key 
 
 func enqueuedSize() uint64 {
 	var total uint64
-	defaultServer.Store().EachQueue(func(q storage.Queue) {
+	defaultServer.Store().EachQueue(func(q types.Queue) {
 		total += q.Size()
 	})
 	return total
@@ -143,7 +143,7 @@ func filtering(set string) string {
 	return ""
 }
 
-func setJobs(set storage.SortedSet, count, currentPage uint64, fn func(idx int, key []byte, job *client.Job)) {
+func setJobs(set types.SortedSet, count, currentPage uint64, fn func(idx int, key []byte, job *client.Job)) {
 	err := set.Page(int64((currentPage-1)*count), int64(count), func(idx int, key []byte, data []byte) error {
 		var job client.Job
 		err := json.Unmarshal(data, &job)
@@ -181,7 +181,7 @@ func busyWorkers(fn func(proc *server.ClientData)) {
 	}
 }
 
-func actOn(set storage.SortedSet, action string, keys []string) error {
+func actOn(set types.SortedSet, action string, keys []string) error {
 	switch action {
 	case "delete":
 		if len(keys) == 1 && keys[0] == "all" {

--- a/webui/morgue.ego
+++ b/webui/morgue.ego
@@ -5,10 +5,10 @@ import (
   "net/http"
 
   "github.com/contribsys/faktory/client"
-  "github.com/contribsys/faktory/storage"
+  "github.com/contribsys/faktory/storage/types"
 )
 
-func ego_listDead(w io.Writer, req *http.Request, set storage.SortedSet, count, currentPage uint64) {
+func ego_listDead(w io.Writer, req *http.Request, set types.SortedSet, count, currentPage uint64) {
   totalSize := uint64(set.Size())
 %>
 

--- a/webui/queue.ego
+++ b/webui/queue.ego
@@ -6,10 +6,10 @@ import (
   "net/http"
 
   "github.com/contribsys/faktory/client"
-  "github.com/contribsys/faktory/storage"
+  "github.com/contribsys/faktory/storage/types"
 )
 
-func ego_queue(w io.Writer, req *http.Request, q storage.Queue, count, currentPage uint64) {
+func ego_queue(w io.Writer, req *http.Request, q types.Queue, count, currentPage uint64) {
   ego_layout(w, req, func() { %>
 
 <header class="row">

--- a/webui/retries.ego
+++ b/webui/retries.ego
@@ -5,10 +5,10 @@ import (
   "net/http"
 
   "github.com/contribsys/faktory/client"
-  "github.com/contribsys/faktory/storage"
+  "github.com/contribsys/faktory/storage/types"
 )
 
-func ego_listRetries(w io.Writer, req *http.Request, set storage.SortedSet, count, currentPage uint64) {
+func ego_listRetries(w io.Writer, req *http.Request, set types.SortedSet, count, currentPage uint64) {
   totalSize := uint64(set.Size())
 %>
 

--- a/webui/scheduled.ego
+++ b/webui/scheduled.ego
@@ -5,10 +5,10 @@ import (
   "net/http"
 
   "github.com/contribsys/faktory/client"
-  "github.com/contribsys/faktory/storage"
+  "github.com/contribsys/faktory/storage/types"
 )
 
-func ego_listScheduled(w io.Writer, req *http.Request, set storage.SortedSet, count, currentPage uint64) {
+func ego_listScheduled(w io.Writer, req *http.Request, set types.SortedSet, count, currentPage uint64) {
   totalSize := uint64(set.Size())
 %>
 


### PR DESCRIPTION
This is a PR that moves the rocks-specific code for storage to it's own sub-package. It opens the door for writing multiple storage backends for Faktory (maybe something akin to a replicated storage backend as you briefly mentioned here: https://github.com/contribsys/faktory/issues/149?).

Overall, the rocks stuff was implemented with interfaces in mind anyway, so this is a pretty trivial change, although the change does reveal a bit of coupling that probably needs to be refactored in the `repl.go` file from the cli, namely the assumption that we're working with `rocksdb`:

```
opts := rocksdb.DefaultOptions()
if err := gorocksdb.RepairDb(path, opts); err != nil {
	return err
}
```