### PR TITLE
Shell escape filename when given to shasum

### DIFF
--- a/.github/notes.rb
+++ b/.github/notes.rb
@@ -1,4 +1,5 @@
 require 'erb'
+require 'shellwords'
 
 # GitHub release notes auto-generator
 # Use like `ruby notes.rb 0.9.0`
@@ -11,7 +12,7 @@ sums = {}
 Dir["packaging/output/systemd/*"].each do |fullname|
   name = File.basename(fullname)
 
-  output = `shasum -p -a 256 #{fullname}`
+  output = `shasum -p -a 256 #{Shellwords.escape(fullname)}`
   if $?.exitstatus != 0
     raise output
   end


### PR DESCRIPTION
This prevents filenames with spaces and other oddities from doing unexpected things. Beware of bugs in the above code; I have only proved it correct, not tried it.