### PR TITLE
Close underlying client connection when Client.Close() is called

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -229,7 +229,8 @@ func Dial(srv *Server, password string) (*Client, error) {
 }
 
 func (c *Client) Close() error {
-	return writeLine(c.wtr, "END", nil)
+	writeLine(c.wtr, "END", nil)
+	return c.conn.Close()
 }
 
 func (c *Client) Ack(jid string) error {


### PR DESCRIPTION
This implementation ignores write errors and returns conn.Close() error. The assumption is that users would expect the call to close the connection, hence they'd be interested in the socket closing errors if any.

Closes #183 