### PR TITLE
Ensure we log timeout warnings before overriding

### DIFF
--- a/manager/working.go
+++ b/manager/working.go
@@ -84,13 +84,13 @@ func (m *manager) reserve(wid string, job *client.Job) error {
 	}
 
 	if timeout < 60 {
-		timeout = DefaultTimeout
 		util.Warnf("Timeout too short %d, 60 seconds minimum", timeout)
+		timeout = DefaultTimeout
 	}
 
 	if timeout > 86400 {
-		timeout = DefaultTimeout
 		util.Warnf("Timeout too long %d, one day maximum", timeout)
+		timeout = DefaultTimeout
 	}
 
 	exp := now.Add(time.Duration(timeout) * time.Second)


### PR DESCRIPTION
I noticed that Faktory has a minimum timeout and helpfully logs when you're timeout is too short. Unfortunately, it was resetting to the default timeout before logging, resulting in a confusing log line:

![img_0088](https://user-images.githubusercontent.com/282048/48298223-a5e89080-e487-11e8-8785-9f62a84602f6.jpeg)

This change moves the logging earlier so the log message reflects the current configuration.

![img_0089](https://user-images.githubusercontent.com/282048/48298234-d4ff0200-e487-11e8-906b-d4e9e319555d.jpeg)
