### PR TITLE
Add setup.sh to the Vagrantfile

### DIFF
--- a/build/centos/Vagrantfile
+++ b/build/centos/Vagrantfile
@@ -9,13 +9,13 @@ Vagrant.configure("2") do |config|
   # available at 17419 and 17420 on the host OS.
   config.vm.network "forwarded_port", guest: 7419, host: 17419, host_ip: "127.0.0.1"
   config.vm.network "forwarded_port", guest: 7420, host: 17420, host_ip: "127.0.0.1"
-
+  
+  # Run setup.sh
+  config.vm.provision "shell", path: "setup.sh"
+  
   # If this shared folder fails, you likely need to install the Vagrant
   # guest extensions, install this plugin to do so:
   #
   #   vagrant plugin install vagrant-vbguest
   config.vm.synced_folder "../..", "/faktory"
-  
-  # Run setup.sh
-  config.vm.provision "shell", path: "setup.sh"
 end

--- a/build/centos/Vagrantfile
+++ b/build/centos/Vagrantfile
@@ -15,4 +15,7 @@ Vagrant.configure("2") do |config|
   #
   #   vagrant plugin install vagrant-vbguest
   config.vm.synced_folder "../..", "/faktory"
+  
+  # Run setup.sh
+  config.vm.provision "shell", path: "setup.sh"
 end


### PR DESCRIPTION
Hey there. 

I'm not too familiar with Vagrant, but I couldn't figure how `setup.sh` was getting called during provisioning. This PR will copy that file into the guest host and call it during provisioning.