### PR TITLE
Fix the sorted set iteration

### DIFF
--- a/storage/sorted_redis.go
+++ b/storage/sorted_redis.go
@@ -174,11 +174,10 @@ func (rs *redisSorted) Page(start int, count int, fn func(index int, e SortedEnt
 }
 
 func (rs *redisSorted) Each(fn func(idx int, e SortedEntry) error) error {
-
+	count := 50
+	current := 0
+	
 	for {
-		count := 50
-		current := 0
-
 		elms, err := rs.Page(current, count, fn)
 		if err != nil {
 			return err


### PR DESCRIPTION
The two variables need to be outside of the loop otherwise the iteration will forever go over the same 50 first items.

In practice, it means that if Faktory is restarted with more than 50 active jobs, it will never fully start and stay in an endless loop.