### PR TITLE
Fix log levels in CLI help output

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -73,7 +73,7 @@ func help() {
 	log.Println("-b [binding]\tNetwork binding (use :7419 to listen on all interfaces), default: localhost:7419")
 	log.Println("-w [binding]\tWeb UI binding (use :7420 to listen on all interfaces), default: localhost:7420")
 	log.Println("-e [env]\tSet environment (development, production), default: development")
-	log.Println("-l [level]\tSet logging level (warn, info, debug, verbose), default: info")
+	log.Println("-l [level]\tSet logging level (error, warn, info, debug), default: info")
 	log.Println("-v\t\tShow version and license information")
 	log.Println("-h\t\tThis help screen")
 }


### PR DESCRIPTION
Hello!

Trivial bug - the CLI ``--help`` output includes an invalid log level ``verbose`` and is missing the valid log level ``error``:

```
$ ./faktory --help
Faktory Pro 1.0.0
© 2019 Contributed Systems LLC.
-b [binding]	Network binding (use :7419 to listen on all interfaces), default: localhost:7419
-w [binding]	Web UI binding (use :7420 to listen on all interfaces), default: localhost:7420
-e [env]	Set environment (development, production), default: development
-l [level]	Set logging level (warn, info, debug, verbose), default: info
-v		Show version and license information
-h		This help screen
```

``verbose`` causes a panic in the underlying ``apex/log`` package:

```
./faktory -l verbose
Faktory Pro 1.0.0
© 2019 Contributed Systems LLC.
panic: invalid log level

goroutine 1 [running]:
github.com/mperham/faktory-comm/pro/vendor/github.com/apex/log.MustParseLevel(0x7ffeefbffaa6, 0x7, 0x9601)
	/Users/mikeperham/src/github.com/mperham/faktory-comm/pro/vendor/github.com/apex/log/levels.go:77 +0x6d
github.com/mperham/faktory-comm/pro/vendor/github.com/apex/log.SetLevelFromString(0x7ffeefbffaa6, 0x7)
	/Users/mikeperham/src/github.com/mperham/faktory-comm/pro/vendor/github.com/apex/log/pkg.go:27 +0x5d
github.com/mperham/faktory-comm/pro/vendor/github.com/contribsys/faktory/util.NewLogger(0x7ffeefbffaa6, 0x7, 0x1, 0x1412368, 0xb)
	/Users/mikeperham/src/github.com/mperham/faktory-comm/pro/vendor/github.com/contribsys/faktory/util/logger.go:74 +0xd4
github.com/mperham/faktory-comm/pro/vendor/github.com/contribsys/faktory/util.InitLogger(0x7ffeefbffaa6, 0x7)
	/Users/mikeperham/src/github.com/mperham/faktory-comm/pro/vendor/github.com/contribsys/faktory/util/util.go:60 +0x3e
main.main()
	/Users/mikeperham/src/github.com/mperham/faktory-comm/pro/cmd/main.go:31 +0x1a0
```