### PR TITLE
Remove `priority` from documentation and tests

### DIFF
--- a/client/job_test.go
+++ b/client/job_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestJobPriority(t *testing.T) {
+func TestJob(t *testing.T) {
 	job := NewJob("yo", 1)
 	assert.EqualValues(t, 25, job.Retry)
 	data, err := json.Marshal(job)

--- a/docs/protocol-specification.md
+++ b/docs/protocol-specification.md
@@ -131,7 +131,6 @@ fields depending on the situation.
 | Field name    | Value type     | When omitted   | Description |
 | ------------- | -------------- | -------------- | ----------- |
 | `queue`       | String         | `default`      | which job queue to push this job onto.
-| `priority`    | Integer [1-9]  | 5              | higher priority jobs are dequeued before lower priority jobs.
 | `reserve_for` | Integer [60+]  | 1800           | number of seconds a job may be held by a worker before it is considered failed.
 | `at`          | RFC3339 string | \<blank\>      | run the job at approximately this time; immediately if blank
 | `retry`       | Integer        | 25             | number of times to retry this job if it fails. 0 discards the failed job, -1 saves the failed job to the dead set.

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -174,5 +174,5 @@ func pushAndPop(t *testing.T, n int, q Queue) {
 func fakeJob() (string, []byte) {
 	jid := util.RandomJid()
 	nows := util.Nows()
-	return jid, []byte(fmt.Sprintf(`{"jid":"%s","created_at":"%s","priority":%d,"queue":"default","args":[1,2,3],"class":"SomeWorker"}`, jid, nows, 5))
+	return jid, []byte(fmt.Sprintf(`{"jid":"%s","created_at":"%s","queue":"default","args":[1,2,3],"class":"SomeWorker"}`, jid, nows, 5))
 }

--- a/webui/static/locales/en.yml
+++ b/webui/static/locales/en.yml
@@ -78,4 +78,3 @@ en: # <---- change this to your locale code
   NotYetEnqueued: Not yet enqueued
   CreatedAt: Created At
   BackToApp: Back to App
-  Priority: Priority


### PR DESCRIPTION
Remove mentions of the `priority` concept from docs and tests to clear up confusion as to whether this option still exists.

Fixes #223