### PR TITLE
Add custom option setters

### DIFF
--- a/client/job.go
+++ b/client/job.go
@@ -7,6 +7,15 @@ import (
 	"time"
 )
 
+const ISO8601 = "2006-01-02T15:04:05Z"
+
+type UniqueUntil string
+
+const (
+	UniqueUntilSuccess UniqueUntil = "success"
+	UniqueUntilStart   UniqueUntil = "start"
+)
+
 type Failure struct {
 	RetryCount   int      `json:"retry_count"`
 	FailedAt     string   `json:"failed_at"`
@@ -72,4 +81,19 @@ func (j *Job) SetCustom(name string, value interface{}) {
 	}
 
 	j.Custom[name] = value
+}
+
+func (j *Job) SetUniqueFor(seconds uint) *Job {
+	j.SetCustom("unique_for", seconds)
+	return j
+}
+
+func (j *Job) SetUniqueUntil(until UniqueUntil) *Job {
+	j.SetCustom("unique_until", until)
+	return j
+}
+
+func (j *Job) SetExpiresAt(expiresAt time.Time) *Job {
+	j.SetCustom("expires_at", expiresAt.Format(ISO8601))
+	return j
 }

--- a/client/job_test.go
+++ b/client/job_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -13,4 +14,16 @@ func TestJob(t *testing.T) {
 	data, err := json.Marshal(job)
 	assert.NoError(t, err)
 	assert.Contains(t, string(data), "retry")
+}
+
+func TestJobCustomOptions(t *testing.T) {
+	job := NewJob("yo", 1)
+	expiresAt := time.Now().Add(1 * time.Hour)
+	job.SetUniqueFor(100).
+		SetUniqueUntil(UniqueUntilStart).
+		SetExpiresAt(expiresAt)
+
+	assert.EqualValues(t, 100, job.Custom["unique_for"])
+	assert.EqualValues(t, UniqueUntilStart, job.Custom["unique_until"])
+	assert.EqualValues(t, expiresAt.Format(ISO8601), job.Custom["expires_at"])
 }


### PR DESCRIPTION
This PR adds three new setters for custom options on a job.

* `SetUniqueFor`
* `SetUniqueUntil`
* `SetExpiresAt`

Additionally, it adds a constant string containing the format needed for an ISO8601 timestamp, as well as  constants for the "unique_until" option.

The setters can be chained in a fluent way:

```
job.SetUniqueFor(100).
	SetUniqueUntil(UniqueUntilStart).
	SetExpiresAt(expiresAt)
```
