### PR TITLE
Read multiple configs safely

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -207,6 +207,7 @@ func readConfig(cdir string, env string) (map[string]interface{}, error) {
 		fmt.Sprintf("%s/conf.d/*.toml", cdir),
 	}
 
+	combined := []byte{}
 	for idx := range globs {
 		matches, err := filepath.Glob(globs[idx])
 		if err != nil {
@@ -220,14 +221,15 @@ func readConfig(cdir string, env string) (map[string]interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
-			err = toml.Unmarshal(fileBytes, &hash)
-			if err != nil {
-				util.Warnf("Unable to parse TOML file at %s", file)
-				return nil, err
-			}
+			combined = append(combined, fileBytes...)
 		}
 	}
 
+	err := toml.Unmarshal(combined, &hash)
+	if err != nil {
+		util.Warnf("Unable to parse configs")
+		return nil, err
+	}
 	return hash, nil
 }
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadConfig(t *testing.T) {
+	wd, _ := os.Getwd()
+	config, _ := readConfig(filepath.Join(wd, "test-fixtures", "case-one"), "")
+
+	schedule := config["cron"].([]map[string]interface{})
+	jobOne := schedule[0]["job"].(map[string]interface{})
+
+	if len(schedule) < 2 {
+		t.Fatalf("Schedule did not include both items %v", schedule)
+	}
+
+	jobTwo := schedule[1]["job"].(map[string]interface{})
+
+	got := jobOne["type"]
+	if got != "OneJob" {
+		t.Errorf("First job in schedule was %v, want OneJob", got)
+	}
+
+	got = jobTwo["type"]
+	if got != "TwoJob" {
+		t.Errorf("Second job in schedule was %v, want TwoJob", got)
+	}
+}

--- a/cli/test-fixtures/case-one/conf.d/a.toml
+++ b/cli/test-fixtures/case-one/conf.d/a.toml
@@ -1,0 +1,5 @@
+[[cron]]
+  schedule = "*/5 * * * *"
+  [cron.job]
+    type = "OneJob"
+    queue = "critical"

--- a/cli/test-fixtures/case-one/conf.d/b.toml
+++ b/cli/test-fixtures/case-one/conf.d/b.toml
@@ -1,0 +1,5 @@
+[[cron]]
+  schedule = "*/5 * * * *"
+  [cron.job]
+    type = "TwoJob"
+    queue = "critical"


### PR DESCRIPTION
## Purpose

Fixes #191

## Approach

Concatenate byte slices of each config file and unmarshal at the end of reading all configs.

## Issue

Subsequent unmarshal was overwriting keys in the cumulative hash of configuration.

## Considerations

Appending bytes from each file and unmarshaling at the end prevents this overwriting from occurring at the cost of not knowing which config has an error if the cumulative contents do not parse correctly.
