### PR TITLE
Add trailing newline during config reading

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -221,6 +221,7 @@ func readConfig(cdir string, env string) (map[string]interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
+			fileBytes = append(fileBytes, "\n"...)
 			combined = append(combined, fileBytes...)
 		}
 	}

--- a/cli/test-fixtures/case-one/conf.d/a.toml
+++ b/cli/test-fixtures/case-one/conf.d/a.toml
@@ -2,4 +2,4 @@
   schedule = "*/5 * * * *"
   [cron.job]
     type = "OneJob"
-    queue = "critical"
+    queue = "critical" # EOF newline intentionally omitted


### PR DESCRIPTION
## Purpose

To prevent a missing trailing newline from creating an invalid concatenation of TOML, which won't parse correctly.

https://github.com/contribsys/faktory/pull/302#issuecomment-631164113

