### PR TITLE
Update version used to build faktory for docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.14.9
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
I encountered an error when running Faktory using the official `contribsys/faktory` image hosted on Ubuntu 20.04:

```
runtime: mlock of signal stack failed: 12
runtime: increase the mlock limit (ulimit -l) or
runtime: update your kernel to 5.3.15+, 5.4.2+, or 5.5+
fatal error: mlock failed
```

This error is traced to [this Go issue](https://github.com/golang/go/issues/37436), in which Go works around a Linux kernel bug. The ultimate resolution of that issue is that once a docker host is upgraded to Ubuntu 20.04, the Go workaround breaks Faktory. This workaround was special cased for Ubuntu in `go1.14.1` (Ubuntu cherry picked the kernel fix into a seemingly older kernel, which Go then tries to apply the work around, then dies).

This PR bumps the CircleCI build image for Faktory to use `go1.14.9`, which was chosen so `contribsys/faktory` would still be on `go1.14.x` (if you want to bump it further, of course feel free).