### PR TITLE
adds Dialer interface enabling custom dialing to faktory server

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -177,7 +177,7 @@ func OpenWithDialer(dialer Dialer) (*Client, error) {
 //
 func Dial(srv *Server, password string) (*Client, error) {
 	d := &net.Dialer{Timeout: srv.Timeout}
-	var dialer Dialer = d
+	dialer := Dialer(d)
 	if srv.Network == "tcp+tls" {
 		dialer = &tls.Dialer{NetDialer: d, Config: srv.TLS}
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -201,6 +201,13 @@ func dial(srv *Server, password string, dialer Dialer) (*Client, error) {
 		return nil, err
 	}
 
+	if x, ok := conn.(*net.TCPConn); ok {
+		err = x.SetKeepAlive(true)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	r := bufio.NewReader(conn)
 	w := bufio.NewWriter(conn)
 


### PR DESCRIPTION
Adds ability to implement a custom way of dialing a faktory server. Accomplishes this by exposing a public `Dialer` interface and functions enabling passing an implementation of that interface. The core change here is to enable faktory to not _need_ to know the specific implementation details of how a client reaches out to a server.

The previous two ways of dialing the server were `tls.DialWithDialer` and `net.Dialer`. These continue to be the default dial methods and are selected following the same logic already present in the codebase. This draft does not propose changing the current public methods so that extent usage is sypported - i.e., no breaking changes.

If a more complicated situation arises the burden is put on the developer to implement the `Dialer` interface the `client` package now exposes.

I have not thought through nor am entirely aware what this change means for faktory's overall support for other languages.

Here's an example custom dialer that needs to with the `tcp+tls` scheme, but _also_ have its connection forwarded by a SOCKSv5 proxy. I'll pass that dialer in when we allocate a new client pool:

```go
import (
        "crypto/tls"
        "net"

        faktory "github.com/contribsys/faktory/client"
        "golang.org/x/net/proxy"
)

// myDialer implements faktory.Dialer
type myDialer struct {
    address string // address to SOCKS5 server, not faktory
    authCfg proxy.Auth
}

// Dial connects to a SOCKS5 proxy server and initiates a tcp connection to the faktory server.
// If successful, a tls handshake is attempted with the faktory server. Once successful, the now
// encrypted connection is returned as a net.Conn.
func (d *myDialer) Dial(n, a string) (net.Conn, error) {
       // Connecting to SOCKS5 proxy is user/pass based and is a regular tcp connection.
       // tls.Dial attempts a TLS handshake with the proxy server, incorrectly.
       sock, err := proxy.SOCKS5("tcp", d.address, d.authCfg, proxy.Direct)
       // handle err

       // I now get a connection to the faktory server after my SOCKS5 forwards the request.
       conn, err := sock.Dial(n, a)
       // handle err

       // Let's setup a tls connection to that faktory server
       tlsConn := tls.Client(conn, &tls.Config{})
       err := tlsConn.Handshake()
       // handleErr

       return net.Conn(tlsConn), nil
}

func NewPool() (*faktory.Pool, error) {
    // setup authCfg, network, address, etc. details relevant to myDialer, but not faktory
    dialer := &myDialer{address: someAddr, authCfg: someCfg}

    pool, err := faktory.NewPoolWithDialer(10, dialer)
    // handle err

    return pool, nil
}
