### PR TITLE
Set minimum TLS version

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -132,7 +132,7 @@ FOO_URL=tcp://:mypassword@faktory.example.com:7419`)
 }
 
 func DefaultServer() *Server {
-	return &Server{"tcp", "localhost:7419", "", 1 * time.Second, &tls.Config{MinVersion: tls.VersionTLS11}}
+	return &Server{"tcp", "localhost:7419", "", 1 * time.Second, &tls.Config{MinVersion: tls.VersionTLS12}}
 }
 
 // Open connects to a Faktory server based on

--- a/client/client.go
+++ b/client/client.go
@@ -132,7 +132,7 @@ FOO_URL=tcp://:mypassword@faktory.example.com:7419`)
 }
 
 func DefaultServer() *Server {
-	return &Server{"tcp", "localhost:7419", "", 1 * time.Second, &tls.Config{}}
+	return &Server{"tcp", "localhost:7419", "", 1 * time.Second, &tls.Config{MinVersion: tls.VersionTLS11}}
 }
 
 // Open connects to a Faktory server based on


### PR DESCRIPTION
This line is triggering a G402 in gosec, since tls.Config defaults tls MinVersion to 1.0: https://golang.org/pkg/crypto/tls/#Config