### PR TITLE
Use crypto/rand for generating salt

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -195,13 +195,18 @@ func startConnection(conn net.Conn, s *Server) *Connection {
 	// 4000 iterations is about 1ms on my 2016 MBP w/ 2.9Ghz Core i5
 	iter := rand.Intn(4096) + 4000
 
+	saltValue, err := util.RandomInt63()
+	if err != nil {
+		util.Error("Couldn't produce salt.", err)
+	}
+
 	var salt string
 	_, _ = conn.Write([]byte(`+HI {"v":2`))
 	if s.Options.Password != "" {
 		_, _ = conn.Write([]byte(`,"i":`))
 		iters := strconv.FormatInt(int64(iter), 10)
 		_, _ = conn.Write([]byte(iters))
-		salt = strconv.FormatInt(rand.Int63(), 16)
+		salt = strconv.FormatInt(saltValue, 16)
 		_, _ = conn.Write([]byte(`,"s":"`))
 		_, _ = conn.Write([]byte(salt))
 		_, _ = conn.Write([]byte(`"}`))

--- a/util/util.go
+++ b/util/util.go
@@ -4,6 +4,7 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"math/big"
 	mathrand "math/rand"
 	"os"
 	"runtime"
@@ -15,6 +16,8 @@ const (
 	SIGINT  = 0x2
 	SIGQUIT = 0x3
 	SIGTERM = 0xF
+
+	maxInt63 = int64(^uint64(0) >> 1)
 )
 
 func Retryable(name string, count int, fn func() error) error {
@@ -55,6 +58,14 @@ func RandomJid() string {
 	}
 
 	return base64.RawURLEncoding.EncodeToString(bytes)
+}
+
+func RandomInt63() (int64, error) {
+	r, err := cryptorand.Int(cryptorand.Reader, big.NewInt(maxInt63))
+	if err != nil {
+		return 0, err
+	}
+	return r.Int64(), nil
 }
 
 const (


### PR DESCRIPTION
In a cryptographic context, crypto/rand should be used for random number generation.