### PR TITLE
Expose queue information on client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -425,6 +425,10 @@ func (c *Client) Queues() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("Invalid info hash: %s", hash)
 	}
 
+	for name, size := range queues {
+		queues[name] = int(size.(float64))
+	}
+
 	return queues, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -414,7 +414,7 @@ func (c *Client) Info() (map[string]interface{}, error) {
 	return hash, nil
 }
 
-func (c *Client) Queues() (map[string]interface{}, error) {
+func (c *Client) QueueSizes() (map[string]uint64, error) {
 	hash, err := c.Info()
 	if err != nil {
 		return nil, err
@@ -425,11 +425,19 @@ func (c *Client) Queues() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("Invalid info hash: %s", hash)
 	}
 
+	sizes := make(map[string]uint64)
 	for name, size := range queues {
-		queues[name] = int(size.(float64))
+		size, ok := size.(float64)
+		if !ok {
+			return nil, fmt.Errorf("Invalid queue size: %v", size)
+		}
+
+		sizes[name] = uint64(size)
 	}
 
-	return queues, nil
+	fmt.Printf("%v", sizes)
+
+	return sizes, nil
 }
 
 func (c *Client) Generic(cmdline string) (string, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -414,6 +414,16 @@ func (c *Client) Info() (map[string]interface{}, error) {
 	return hash, nil
 }
 
+func (c *Client) Queues() (map[string]interface{}, error) {
+	hash, err := c.Info()
+	if err != nil {
+		return nil, err
+	}
+
+	queues := hash["faktory"].(map[string]interface{})["queues"].(map[string]interface{})
+	return queues, nil
+}
+
 func (c *Client) Generic(cmdline string) (string, error) {
 	err := c.writeLine(c.wtr, cmdline, nil)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -420,7 +420,11 @@ func (c *Client) Queues() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	queues := hash["faktory"].(map[string]interface{})["queues"].(map[string]interface{})
+	queues, ok := hash["faktory"].(map[string]interface{})["queues"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Invalid info hash: %s", hash)
+	}
+
 	return queues, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -420,7 +420,12 @@ func (c *Client) QueueSizes() (map[string]uint64, error) {
 		return nil, err
 	}
 
-	queues, ok := hash["faktory"].(map[string]interface{})["queues"].(map[string]interface{})
+	faktory, ok := hash["faktory"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Invalid info hash: %s", hash)
+	}
+
+	queues, ok := faktory["queues"].(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("Invalid info hash: %s", hash)
 	}
@@ -434,8 +439,6 @@ func (c *Client) QueueSizes() (map[string]uint64, error) {
 
 		sizes[name] = uint64(size)
 	}
-
-	fmt.Printf("%v", sizes)
 
 	return sizes, nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -109,9 +109,15 @@ func TestClientOperations(t *testing.T) {
 		assert.Contains(t, <-req, "INFO")
 
 		resp <- "$36\r\n{\"faktory\":{\"queues\":{\"default\":2}}}\r\n"
-		queues, err := cl.Queues()
+		sizes, err := cl.QueueSizes()
 		assert.NoError(t, err)
-		assert.Equal(t, queues["default"], 2)
+		assert.Equal(t, sizes["default"], uint64(2))
+		assert.Contains(t, <-req, "INFO")
+		
+		resp <- "$39\r\n{\"faktory\":{\"queues\":{\"invalid\":null}}}\r\n"
+		sizes, err = cl.QueueSizes()
+		assert.Error(t, err)
+		assert.Nil(t, sizes)
 		assert.Contains(t, <-req, "INFO")
 
 		err = cl.Close()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -113,7 +113,7 @@ func TestClientOperations(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, sizes["default"], uint64(2))
 		assert.Contains(t, <-req, "INFO")
-		
+
 		resp <- "$39\r\n{\"faktory\":{\"queues\":{\"invalid\":null}}}\r\n"
 		sizes, err = cl.QueueSizes()
 		assert.Error(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -111,7 +111,7 @@ func TestClientOperations(t *testing.T) {
 		resp <- "$36\r\n{\"faktory\":{\"queues\":{\"default\":2}}}\r\n"
 		queues, err := cl.Queues()
 		assert.NoError(t, err)
-		assert.Equal(t, queues["default"], float64(2))
+		assert.Equal(t, queues["default"], 2)
 		assert.Contains(t, <-req, "INFO")
 
 		err = cl.Close()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -108,10 +108,15 @@ func TestClientOperations(t *testing.T) {
 		assert.NotNil(t, hash)
 		assert.Contains(t, <-req, "INFO")
 
+		resp <- "$36\r\n{\"faktory\":{\"queues\":{\"default\":2}}}\r\n"
+		queues, err := cl.Queues()
+		assert.NoError(t, err)
+		assert.Equal(t, queues["default"], float64(2))
+		assert.Contains(t, <-req, "INFO")
+
 		err = cl.Close()
 		assert.NoError(t, err)
 		assert.Contains(t, <-req, "END")
-
 	})
 }
 


### PR DESCRIPTION
Added method on client to expose information (the size) of all queues. Because of the loose structure of the info hash (`map[string]interface{})`, the size is a `float64` instead of an `int`.