### PR TITLE
add OK response for END command

### DIFF
--- a/server/commands.go
+++ b/server/commands.go
@@ -85,6 +85,7 @@ func flush(c *Connection, s *Server, cmd string) {
 
 // END
 func end(c *Connection, s *Server, cmd string) {
+	_ = c.Ok()
 	c.Close()
 }
 


### PR DESCRIPTION
Minor fix to meet FWD specification for END command responses

https://github.com/contribsys/faktory/blob/master/docs/protocol-specification.md#end-command

```
If the client requests the end state, the server MUST send an OK response to the END command before the server closes the connection; and the client MUST read the OK response to the END command before the client closes the connection.
```