### PR TITLE
Fix comment providing an invalid example

### DIFF
--- a/client/batch.go
+++ b/client/batch.go
@@ -47,7 +47,6 @@ type Batch struct {
 //   b.Jobs(func() error {
 //     b.Push(...)
 //   })
-//   b.Commit()
 //
 func NewBatch(cl *Client) *Batch {
 	return &Batch{


### PR DESCRIPTION
The original examples shows to call `batch.Commit()`. However, `batch.Jobs()` already calls it and the example code will cause an error stating that the batch has already been committed.

Remove the line which is not required.
