### PR TITLE
Allow batches to push jobs in bulk

### DIFF
--- a/client/batch.go
+++ b/client/batch.go
@@ -89,6 +89,22 @@ func (b *Batch) Push(job *Job) error {
 	return b.faktory.Push(job)
 }
 
+// Result is map[JID]ErrorMessage
+func (b *Batch) PushBulk(job []*Job) (map[string]string, error) {
+	if b.new {
+		return nil, ErrBatchNotOpen
+	}
+	if b.faktory == nil || b.committed {
+		return nil, ErrBatchAlreadyCommitted
+	}
+
+	for _, job := range jobs {
+		job.SetCustom("bid", b.Bid)
+	}
+	
+	return b.faktory.PushBulk(jobs)
+}
+
 // Commit any pushed jobs in the batch to Redis so they can fire callbacks.
 // A Batch object can only be committed once.
 // You must use client.BatchOpen to get a new copy if you want to commit more jobs.


### PR DESCRIPTION
# Context

Faktory 1.6.0 introduced the `BULKB` command which allows jobs to be pushed in bulk, and the Faktory Client introduced the `PushBulk` method in order to add support for it.

# Problem

Although the feature should also work with Batches out of the box, currently the Faktory Client's `Batch` API doesn't implement the `PushBulk` functionality.

# Solution

This MR adds the `PushBulk` method to Faktory's Client Batch API in order to allow Jobs to be pushed in bulk within Batches.