### PR TITLE
limit days length

### DIFF
--- a/storage/history.go
+++ b/storage/history.go
@@ -35,7 +35,7 @@ func (store *redisStore) Failure(ctx context.Context) error {
 
 func (store *redisStore) History(ctx context.Context, days int, fn func(day string, procCnt uint64, failCnt uint64)) error {
 	if days > 180 {
-		return errors.New("days value cannot be greater than 180")
+		return errors.New("days value can't be greater than 180")
 	}
 	ts := time.Now()
 	daystrs := make([]string, days)

--- a/storage/history.go
+++ b/storage/history.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -33,6 +34,9 @@ func (store *redisStore) Failure(ctx context.Context) error {
 }
 
 func (store *redisStore) History(ctx context.Context, days int, fn func(day string, procCnt uint64, failCnt uint64)) error {
+	if days > 180 {
+		return errors.New("days value cannot be greater than 180")
+	}
 	ts := time.Now()
 	daystrs := make([]string, days)
 	fails := make([]*redis.IntCmd, days)

--- a/webui/helpers.go
+++ b/webui/helpers.go
@@ -338,6 +338,9 @@ func days(req *http.Request) int {
 	if err != nil {
 		return 30
 	}
+	if cnt > 180 {
+		return 180
+	}
 	return cnt
 }
 


### PR DESCRIPTION
limit the `days` length from URL query parameter to prevent out-of-memory in the `(store *redisStore) History` function