### PR TITLE
Unwrap ActiveJob job class in WebUI

### DIFF
--- a/webui/busy.ego
+++ b/webui/busy.ego
@@ -110,7 +110,7 @@ func ego_busy(w io.Writer, req *http.Request) {
         <td>
           <a href="<%= root(req) %>/queues/<%= job.Queue %>"><%= job.Queue %></a>
         </td>
-        <td><code><%= job.Type %></code></td>
+        <td><code><%= displayJobType(job) %></code></td>
         <td>
           <div class="args"><%= displayArgs(job.Args) %></div>
         </td>

--- a/webui/busy.ego.go
+++ b/webui/busy.ego.go
@@ -214,7 +214,7 @@ func ego_busy(w io.Writer, req *http.Request) {
 //line busy.ego:111
 			_, _ = io.WriteString(w, "</a>\n        </td>\n        <td><code>")
 //line busy.ego:113
-			_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(job.Type)))
+			_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(displayJobType(job))))
 //line busy.ego:113
 			_, _ = io.WriteString(w, "</code></td>\n        <td>\n          <div class=\"args\">")
 //line busy.ego:115

--- a/webui/helpers.go
+++ b/webui/helpers.go
@@ -419,6 +419,22 @@ func displayJobType(j *client.Job) string {
 	if j.Type == "ActiveJob::QueueAdapters::FaktoryAdapter::JobWrapper" {
 		jobClass, ok := j.Custom["wrapped"].(string)
 		if ok {
+			if jobClass == "ActionMailer::DeliveryJob" || jobClass == "ActionMailer::MailDeliveryJob" {
+				args, ok := j.Args[0].(map[string]interface{})
+				if ok {
+					// Get the actual job arguments
+					arguments, ok := args["arguments"].([]interface{})
+					if ok {
+						if len(arguments) >= 2 {
+							mailerClass, ok1 := arguments[0].(string)
+							mailerMethod, ok2 := arguments[1].(string)
+							if ok1 && ok2 {
+								return fmt.Sprintf("%s#%s", mailerClass, mailerMethod)
+							}
+						}
+					}
+				}
+			}
 			return jobClass
 		}
 	}

--- a/webui/helpers.go
+++ b/webui/helpers.go
@@ -415,6 +415,14 @@ func sortedLocaleNames(req *http.Request, fn func(string, bool)) {
 	}
 }
 
+func displayJobType(j *client.Job) string {
+	if j.Type == "ActiveJob::QueueAdapters::FaktoryAdapter::JobWrapper" {
+		args := j.Args[0].(map[string]interface{})
+		return args["job_class"].(string)
+	}
+	return j.Type
+}
+
 func displayArgs(args []interface{}) string {
 	return displayLimitedArgs(args, 1024)
 }

--- a/webui/helpers.go
+++ b/webui/helpers.go
@@ -417,12 +417,9 @@ func sortedLocaleNames(req *http.Request, fn func(string, bool)) {
 
 func displayJobType(j *client.Job) string {
 	if j.Type == "ActiveJob::QueueAdapters::FaktoryAdapter::JobWrapper" {
-		args, ok := j.Args[0].(map[string]interface{})
+		jobClass, ok := j.Custom["wrapped"].(string)
 		if ok {
-			jobClass, ok := args["job_class"].(string)
-			if ok {
-				return jobClass
-			}
+			return jobClass
 		}
 	}
 	return j.Type

--- a/webui/helpers.go
+++ b/webui/helpers.go
@@ -417,8 +417,13 @@ func sortedLocaleNames(req *http.Request, fn func(string, bool)) {
 
 func displayJobType(j *client.Job) string {
 	if j.Type == "ActiveJob::QueueAdapters::FaktoryAdapter::JobWrapper" {
-		args := j.Args[0].(map[string]interface{})
-		return args["job_class"].(string)
+		args, ok := j.Args[0].(map[string]interface{})
+		if ok {
+			jobClass, ok := args["job_class"].(string)
+			if ok {
+				return jobClass
+			}
+		}
 	}
 	return j.Type
 }

--- a/webui/helpers_test.go
+++ b/webui/helpers_test.go
@@ -54,6 +54,58 @@ func makeActiveJob(jobType string) *client.Job {
 	return job
 }
 
+func makeActionMailerJob(jobType string, mailerClass string, mailerMethod string) *client.Job {
+	var payload = []byte(fmt.Sprintf(`
+{
+  "jid": "60259247a836111c54b5ddf7",
+  "queue": "default",
+  "jobtype": "ActiveJob::QueueAdapters::FaktoryAdapter::JobWrapper",
+  "args": [
+    {
+      "arguments": [
+        "%[2]s",
+        "%[3]s",
+        "deliver_now",
+        {
+          "_aj_ruby2_keywords": [
+            "args"
+          ],
+          "args": [
+            {
+              "_aj_globalid": "gid://app/User/1"
+            }
+          ]
+        }
+      ],
+      "enqueued_at": "2023-12-20T21:35:27.281042097Z",
+      "exception_executions": {},
+      "executions": 0,
+      "job_class": "%[1]s",
+      "job_id": "0667e00a-61e4-4936-af9f-8ba494c060a0",
+      "locale": "en",
+      "priority": null,
+      "provider_job_id": "60259247a836111c54b5ddf7",
+      "queue_name": "default",
+      "scheduled_at": null,
+      "timezone": "Pacific Time (US & Canada)"
+    }
+  ],
+  "created_at": "2023-12-20T21:35:27.281126796Z",
+  "enqueued_at": "2023-12-20T21:35:27.281128369Z",
+  "retry": 3,
+  "custom": {
+    "wrapped": "%[1]s"
+  }
+}
+`, jobType, mailerClass, mailerMethod))
+	job := &client.Job{}
+	err := json.Unmarshal(payload, job)
+	if err != nil {
+		panic(err)
+	}
+	return job
+}
+
 var testCases = []testJob{
 	{
 		name:     "simple",
@@ -64,6 +116,16 @@ var testCases = []testJob{
 		name:     "wrapped",
 		job:      makeActiveJob("FooJob"),
 		expected: "FooJob",
+	},
+	{
+		name:     "Rails 5.x mailer",
+		job:      makeActionMailerJob("ActionMailer::DeliveryJob", "UserMailer", "welcome"),
+		expected: "UserMailer#welcome",
+	},
+	{
+		name:     "Rails 6.x mailer",
+		job:      makeActionMailerJob("ActionMailer::MailDeliveryJob", "UserMailer", "welcome"),
+		expected: "UserMailer#welcome",
 	},
 }
 

--- a/webui/helpers_test.go
+++ b/webui/helpers_test.go
@@ -1,6 +1,8 @@
 package webui
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/contribsys/faktory/client"
@@ -12,6 +14,46 @@ type testJob struct {
 	expected string
 }
 
+func makeActiveJob(jobType string) *client.Job {
+	var payload = []byte(fmt.Sprintf(`
+{
+  "jid": "bb2a34025e7ce72a064d10d6",
+  "queue": "default",
+  "jobtype": "ActiveJob::QueueAdapters::FaktoryAdapter::JobWrapper",
+  "args": [
+    {
+      "arguments": [
+        1, 2, 3
+      ],
+      "enqueued_at": "2023-12-20T20:36:09.423631911Z",
+      "exception_executions": {},
+      "executions": 0,
+      "job_class": "%[1]s",
+      "job_id": "b24332fc-49bb-4128-8c4c-230c47abea91",
+      "locale": "en",
+      "priority": null,
+      "provider_job_id": "bb2a34025e7ce72a064d10d6",
+      "queue_name": "default",
+      "scheduled_at": null,
+      "timezone": "Pacific Time (US & Canada)"
+    }
+  ],
+  "created_at": "2023-12-20T20:36:09.423723003Z",
+  "enqueued_at": "2023-12-20T20:36:09.423725007Z",
+  "retry": 3,
+  "custom": {
+    "wrapped": "%[1]s"
+  }
+}
+`, jobType))
+	job := &client.Job{}
+	err := json.Unmarshal(payload, job)
+	if err != nil {
+		panic(err)
+	}
+	return job
+}
+
 var testCases = []testJob{
 	{
 		name:     "simple",
@@ -20,7 +62,7 @@ var testCases = []testJob{
 	},
 	{
 		name:     "wrapped",
-		job:      client.NewJob("ActiveJob::QueueAdapters::FaktoryAdapter::JobWrapper", "[{job_class: 'FooJob', args: [1]}]"),
+		job:      makeActiveJob("FooJob"),
 		expected: "FooJob",
 	},
 }

--- a/webui/helpers_test.go
+++ b/webui/helpers_test.go
@@ -1,0 +1,37 @@
+package webui
+
+import (
+	"testing"
+
+	"github.com/contribsys/faktory/client"
+)
+
+type testJob struct {
+	name     string
+	job      *client.Job
+	expected string
+}
+
+var testCases = []testJob{
+	{
+		name:     "simple",
+		job:      client.NewJob("foo_job", 1),
+		expected: "foo_job",
+	},
+	{
+		name:     "wrapped",
+		job:      client.NewJob("ActiveJob::QueueAdapters::FaktoryAdapter::JobWrapper", "[{job_class: 'FooJob', args: [1]}]"),
+		expected: "FooJob",
+	},
+}
+
+func TestActiveJobUnwrapping(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := displayJobType(tc.job)
+			if tc.expected != result {
+				t.Errorf("Expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}

--- a/webui/job_info.ego
+++ b/webui/job_info.ego
@@ -26,7 +26,7 @@ func ego_job_info(w io.Writer, req *http.Request, job *client.Job) {
       <tr>
         <th><%= t(req, "Job") %></th>
         <td>
-          <code><%= job.Type %></code>
+          <code><%= displayJobType(job) %></code>
         </td>
       </tr>
       <tr>

--- a/webui/job_info.ego.go
+++ b/webui/job_info.ego.go
@@ -33,7 +33,7 @@ func ego_job_info(w io.Writer, req *http.Request, job *client.Job) {
 //line job_info.ego:27
 	_, _ = io.WriteString(w, "</th>\n        <td>\n          <code>")
 //line job_info.ego:29
-	_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(job.Type)))
+	_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(displayJobType(job))))
 //line job_info.ego:29
 	_, _ = io.WriteString(w, "</code>\n        </td>\n      </tr>\n      <tr>\n        <th>")
 //line job_info.ego:33

--- a/webui/morgue.ego
+++ b/webui/morgue.ego
@@ -58,7 +58,7 @@ func ego_listDead(w io.Writer, req *http.Request, set storage.SortedSet, count, 
             <td>
               <a href="<%= root(req) %>/queues/<%= job.Queue %>"><%= job.Queue %></a>
             </td>
-            <td><code><%= job.Type %></code></td>
+            <td><code><%= displayJobType(job) %></code></td>
             <td>
               <div class="args"><%= displayArgs(job.Args) %></div>
             </td>

--- a/webui/morgue.ego.go
+++ b/webui/morgue.ego.go
@@ -111,7 +111,7 @@ func ego_listDead(w io.Writer, req *http.Request, set storage.SortedSet, count, 
 //line morgue.ego:59
 				_, _ = io.WriteString(w, "</a>\n            </td>\n            <td><code>")
 //line morgue.ego:61
-				_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(job.Type)))
+				_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(displayJobType(job))))
 //line morgue.ego:61
 				_, _ = io.WriteString(w, "</code></td>\n            <td>\n              <div class=\"args\">")
 //line morgue.ego:63

--- a/webui/queue.ego
+++ b/webui/queue.ego
@@ -39,7 +39,7 @@ func ego_queue(w io.Writer, req *http.Request, q storage.Queue, count, currentPa
         <tr>
           <td><input type="checkbox" name="bkey" value="<%= base64.RawURLEncoding.EncodeToString(key) %>" /></td>
           <td><%= job.Jid %></td>
-          <td><%= job.Type %></td>
+          <td><%= displayJobType(job) %></td>
           <td><div class="args"><%= displayArgs(job.Args) %></div></td>
         </tr>
       <% }) %>

--- a/webui/queue.ego.go
+++ b/webui/queue.ego.go
@@ -68,7 +68,7 @@ func ego_queue(w io.Writer, req *http.Request, q storage.Queue, count, currentPa
 //line queue.ego:41
 			_, _ = io.WriteString(w, "</td>\n          <td>")
 //line queue.ego:42
-			_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(job.Type)))
+			_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(displayJobType(job))))
 //line queue.ego:42
 			_, _ = io.WriteString(w, "</td>\n          <td><div class=\"args\">")
 //line queue.ego:43

--- a/webui/retries.ego
+++ b/webui/retries.ego
@@ -61,7 +61,7 @@ func ego_listRetries(w io.Writer, req *http.Request, set storage.SortedSet, coun
             <td>
               <a href="<%= root(req) %>/queues/<%= job.Queue %>"><%= job.Queue %></a>
             </td>
-            <td><code><%= job.Type %></code></td>
+            <td><code><%= displayJobType(job) %></code></td>
             <td>
               <div class="args"><%= displayArgs(job.Args) %></div>
             </td>

--- a/webui/retries.ego.go
+++ b/webui/retries.ego.go
@@ -119,7 +119,7 @@ func ego_listRetries(w io.Writer, req *http.Request, set storage.SortedSet, coun
 //line retries.ego:62
 				_, _ = io.WriteString(w, "</a>\n            </td>\n            <td><code>")
 //line retries.ego:64
-				_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(job.Type)))
+				_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(displayJobType(job))))
 //line retries.ego:64
 				_, _ = io.WriteString(w, "</code></td>\n            <td>\n              <div class=\"args\">")
 //line retries.ego:66

--- a/webui/scheduled.ego
+++ b/webui/scheduled.ego
@@ -54,7 +54,7 @@ func ego_listScheduled(w io.Writer, req *http.Request, set storage.SortedSet, co
             <td>
               <a href="<%= root(req) %>/queues/<%= job.Queue %>"><%= job.Queue %></a>
             </td>
-            <td><code><%= job.Type %></code></td>
+            <td><code><%= displayJobType(job) %></code></td>
             <td>
                <div class="args"><%= displayArgs(job.Args) %></div>
             </td>

--- a/webui/scheduled.ego.go
+++ b/webui/scheduled.ego.go
@@ -107,7 +107,7 @@ func ego_listScheduled(w io.Writer, req *http.Request, set storage.SortedSet, co
 //line scheduled.ego:55
 				_, _ = io.WriteString(w, "</a>\n            </td>\n            <td><code>")
 //line scheduled.ego:57
-				_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(job.Type)))
+				_, _ = io.WriteString(w, html.EscapeString(fmt.Sprint(displayJobType(job))))
 //line scheduled.ego:57
 				_, _ = io.WriteString(w, "</code></td>\n            <td>\n               <div class=\"args\">")
 //line scheduled.ego:59


### PR DESCRIPTION
Unwraps ActiveJob job classes in the web UI.

This does not unwrap the arguments, but that would be a nice addition as well.

Based on similar logic from Sidekiq, thanks for the pointer @mperham! I barely understand Go so I hope the code is okay.

https://github.com/sidekiq/sidekiq/blob/73c150d0430a8394cadb5cd49218895b113613a0/lib/sidekiq/api.rb#L374-L389

Fixes #459