### PR TITLE
Use json.Number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.20"
+        go-version: "1.22"
 
     - name: Prepare
       run: make prepare

--- a/.github/workflows/ent.yml
+++ b/.github/workflows/ent.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
     env:
       GO_VERSION: "1.22"
-      FAKTORY_VERSION: 1.9.0
+      FAKTORY_VERSION: 1.8.0
     steps:
       - uses: actions/checkout@v4
       - name: Install redis

--- a/.github/workflows/ent.yml
+++ b/.github/workflows/ent.yml
@@ -15,8 +15,8 @@ jobs:
   test:
     runs-on: macos-latest
     env:
-      GO_VERSION: "1.21"
-      FAKTORY_VERSION: 1.8.0
+      GO_VERSION: "1.22"
+      FAKTORY_VERSION: 1.9.0
     steps:
       - uses: actions/checkout@v4
       - name: Install redis

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ clean: ## Clean the project, set it up for a new build
 	@mkdir -p packaging/output/upstart
 	@mkdir -p packaging/output/systemd
 	@mkdir -p tmp/linux
+	@go clean -testcache
 
 run: clean generate ## Run Faktory daemon locally
 	FAKTORY_PASSWORD=${PASSWORD} go run cmd/faktory/daemon.go -l debug -e development

--- a/client/batch.go
+++ b/client/batch.go
@@ -3,6 +3,8 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/contribsys/faktory/util"
 )
 
 type BatchStatus struct {
@@ -176,7 +178,7 @@ func (c *Client) BatchStatus(bid string) (*BatchStatus, error) {
 	}
 
 	var stat BatchStatus
-	err = json.Unmarshal(data, &stat)
+	err = util.JsonUnmarshal(data, &stat)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bufio"
-	"fmt"
 	"log"
 	"net"
 	"os"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -157,7 +157,6 @@ func withFakeServer(t *testing.T, fn func(chan string, chan string, string)) {
 			buf := bufio.NewReader(conn)
 			line, err := buf.ReadString('\n')
 			if err != nil {
-				fmt.Println(err)
 				conn.Close()
 				break
 			}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -122,13 +122,13 @@ func TestClientOperations(t *testing.T) {
 		resp <- "$36\r\n{\"faktory\":{\"queues\":{\"default\":2}}}\r\n"
 		sizes, err := cl.QueueSizes()
 		assert.NoError(t, err)
-		assert.Equal(t, sizes["default"], uint64(2))
+		assert.EqualValues(t, 2, sizes["default"])
 		assert.Contains(t, <-req, "INFO")
 
 		resp <- "$39\r\n{\"faktory\":{\"queues\":{\"invalid\":null}}}\r\n"
 		sizes, err = cl.QueueSizes()
-		assert.Error(t, err)
-		assert.Nil(t, sizes)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 0, sizes["invalid"])
 		assert.Contains(t, <-req, "INFO")
 
 		err = cl.Close()

--- a/client/faktory.go
+++ b/client/faktory.go
@@ -4,3 +4,30 @@ var (
 	Name    = "Faktory"
 	Version = "1.9.0"
 )
+
+// Structs for parsing the INFO response
+type FaktoryState struct {
+	Now           string         `json:"now"`
+	ServerUtcTime string         `json:"server_utc_time"`
+	Data          DataSnapshot   `json:"faktory"`
+	Server        ServerSnapshot `json:"server"`
+}
+
+type DataSnapshot struct {
+	TotalFailures  uint64                            `json:"total_failures"`
+	TotalProcessed uint64                            `json:"total_processed"`
+	TotalEnqueued  uint64                            `json:"total_enqueued"`
+	TotalQueues    uint64                            `json:"total_queues"`
+	Queues         map[string]uint64                 `json:"queues"`
+	Sets           map[string]uint64                 `json:"sets"`
+	Tasks          map[string]map[string]interface{} `json:"tasks"` // deprecated
+}
+
+type ServerSnapshot struct {
+	Description  string `json:"description"`
+	Version      string `json:"faktory_version"`
+	Uptime       uint64 `json:"uptime"`
+	Connections  uint64 `json:"connections"`
+	CommandCount uint64 `json:"command_count"`
+	UsedMemoryMB uint64 `json:"used_memory_mb"`
+}

--- a/client/tracking.go
+++ b/client/tracking.go
@@ -28,7 +28,7 @@ func (c *Client) TrackGet(jid string) (*JobTrack, error) {
 	}
 
 	var trck JobTrack
-	err = json.Unmarshal(data, &trck)
+	err = util.JsonUnmarshal(data, &trck)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/justinas/nosurf v1.1.1
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.9.0
 )
 
 require github.com/redis/go-redis/v9 v9.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/contribsys/faktory
 
-go 1.21
+go 1.22
 
 require (
 	github.com/BurntSushi/toml v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,6 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/contribsys/faktory_worker_go v1.6.0 h1:ov69BLHL62i/wRLJwvuj5UphwgjMOINRCGW3KzrKOjk=
 github.com/contribsys/faktory_worker_go v1.6.0/go.mod h1:XMNGn3sBJdqFGfTH4SkmYkMovhdkq5cDJj36wowfbNY=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
@@ -19,15 +18,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.2.0 h1:zwMdX0A4eVzse46YN18QhuDiM4uf3JmkOB4VZrdt5uI=
 github.com/redis/go-redis/v9 v9.2.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/manager/fetch.go
+++ b/manager/fetch.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -158,7 +157,7 @@ func (el *simpleLease) Job() (*client.Job, error) {
 	}
 	if el.job == nil {
 		var job client.Job
-		err := json.Unmarshal(el.payload, &job)
+		err := util.JsonUnmarshal(el.payload, &job)
 		if err != nil {
 			return nil, fmt.Errorf("cannot unmarshal job payload: %w", err)
 		}

--- a/manager/scheduler.go
+++ b/manager/scheduler.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -38,7 +37,7 @@ func (m *manager) schedule(ctx context.Context, when time.Time, set storage.Sort
 	for {
 		count, err := set.RemoveBefore(ctx, util.Thens(when), 100, func(data []byte) error {
 			var job client.Job
-			if err := json.Unmarshal(data, &job); err != nil {
+			if err := util.JsonUnmarshal(data, &job); err != nil {
 				return fmt.Errorf("cannot unmarshal job payload: %w", err)
 			}
 

--- a/manager/working.go
+++ b/manager/working.go
@@ -83,7 +83,7 @@ func (m *manager) loadWorkingSet(ctx context.Context) error {
 	addedCount := 0
 	err := m.store.Working().Each(ctx, func(idx int, entry storage.SortedEntry) error {
 		var res Reservation
-		err := json.Unmarshal(entry.Value(), &res)
+		err := util.JsonUnmarshal(entry.Value(), &res)
 		if err != nil {
 			//  We can't return an error here, this method is best effort
 			// as we are booting the server. We can't allow corrupted data
@@ -193,7 +193,7 @@ func (m *manager) ReapExpiredJobs(ctx context.Context, when time.Time) (int64, e
 		tm := util.Thens(when)
 		count, err := m.store.Working().RemoveBefore(ctx, tm, 10, func(data []byte) error {
 			var res Reservation
-			err := json.Unmarshal(data, &res)
+			err := util.JsonUnmarshal(data, &res)
 			if err != nil {
 				return fmt.Errorf("cannot unmarshal reservation payload: %w", err)
 			}

--- a/server/commands.go
+++ b/server/commands.go
@@ -100,7 +100,7 @@ func pushBulk(c *Connection, s *Server, cmd string) {
 	data := cmd[6:]
 	jobs := make([]client.Job, 0)
 
-	err := json.Unmarshal([]byte(data), &jobs)
+	err := util.JsonUnmarshal([]byte(data), &jobs)
 	if err != nil {
 		_ = c.Error(cmd, fmt.Errorf("invalid JSON: %w", err))
 		return
@@ -147,7 +147,7 @@ func push(c *Connection, s *Server, cmd string) {
 	var job client.Job
 	job.Retry = &client.RetryPolicyDefault
 
-	err := json.Unmarshal([]byte(data), &job)
+	err := util.JsonUnmarshal([]byte(data), &job)
 	if err != nil {
 		_ = c.Error(cmd, fmt.Errorf("invalid JSON: %w", err))
 		return
@@ -201,7 +201,7 @@ func ack(c *Connection, s *Server, cmd string) {
 	data := cmd[4:]
 
 	var hash map[string]string
-	err := json.Unmarshal([]byte(data), &hash)
+	err := util.JsonUnmarshal([]byte(data), &hash)
 	if err != nil {
 		_ = c.Error(cmd, fmt.Errorf("invalid ACK %s", data))
 		return
@@ -225,7 +225,7 @@ func fail(c *Connection, s *Server, cmd string) {
 	data := cmd[5:]
 
 	var failure manager.FailPayload
-	err := json.Unmarshal([]byte(data), &failure)
+	err := util.JsonUnmarshal([]byte(data), &failure)
 	if err != nil {
 		_ = c.Error(cmd, fmt.Errorf("invalid FAIL %s", data))
 		return
@@ -266,7 +266,7 @@ func heartbeat(c *Connection, s *Server, cmd string) {
 	data := cmd[5:]
 
 	var beat ClientBeat
-	err := json.Unmarshal([]byte(data), &beat)
+	err := util.JsonUnmarshal([]byte(data), &beat)
 	if err != nil {
 		_ = c.Error(cmd, fmt.Errorf("invalid BEAT %s", data))
 		return

--- a/server/mutate.go
+++ b/server/mutate.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/contribsys/faktory/client"
 	"github.com/contribsys/faktory/manager"
 	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/util"
 )
 
 var (
@@ -119,7 +119,7 @@ func mutate(c *Connection, s *Server, cmd string) {
 
 	var err error
 	var op client.Operation
-	err = json.Unmarshal([]byte(parts[1]), &op)
+	err = util.JsonUnmarshal([]byte(parts[1]), &op)
 	if err != nil {
 		_ = c.Error(cmd, err)
 		return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/contribsys/faktory/storage"
+	"github.com/contribsys/faktory/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -104,7 +105,7 @@ func TestServerStart(t *testing.T) {
 		assert.Regexp(t, "\"retry\":", result)
 
 		hash := make(map[string]interface{})
-		err = json.Unmarshal([]byte(result), &hash)
+		err = util.JsonUnmarshal([]byte(result), &hash)
 		assert.NoError(t, err)
 		// fmt.Println(hash)
 		assert.Equal(t, "12345678901234567890abcd", hash["jid"])
@@ -127,7 +128,7 @@ func TestServerStart(t *testing.T) {
 		assert.NoError(t, err)
 
 		var stats map[string]interface{}
-		err = json.Unmarshal([]byte(result), &stats)
+		err = util.JsonUnmarshal([]byte(result), &stats)
 		assert.NoError(t, err)
 		assert.Equal(t, 4, len(stats))
 

--- a/server/workers.go
+++ b/server/workers.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"io"
 	"sync"
 	"time"
@@ -9,7 +8,6 @@ import (
 	"github.com/contribsys/faktory/util"
 )
 
-//
 // This represents a single client process.  It may have many network
 // connections open to Faktory.
 //
@@ -30,7 +28,7 @@ import (
 //
 // A worker process has a simple three-state lifecycle:
 //
-//  running -> quiet -> terminate
+//	running -> quiet -> terminate
 //
 // - Running means the worker is alive and processing jobs.
 // - Quiet means the worker should stop FETCHing new jobs but continue working on existing jobs.
@@ -47,7 +45,6 @@ import (
 //
 // Workers will typically also respond to standard Unix signals.
 // faktory_worker_ruby uses TSTP ("Threads SToP") as the quiet signal and TERM as the terminate signal.
-//
 type ClientData struct {
 	Hostname     string   `json:"hostname"`
 	Wid          string   `json:"wid"`
@@ -98,7 +95,7 @@ func stateFromString(state string) WorkerState {
 
 func clientDataFromHello(data string) (*ClientData, error) {
 	var client ClientData
-	err := json.Unmarshal([]byte(data), &client)
+	err := util.JsonUnmarshal([]byte(data), &client)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/sorted_redis.go
+++ b/storage/sorted_redis.go
@@ -154,7 +154,7 @@ func (e *setEntry) Job() (*client.Job, error) {
 	}
 
 	var job client.Job
-	err := json.Unmarshal(e.value, &job)
+	err := util.JsonUnmarshal(e.value, &job)
 	if err != nil {
 		return nil, err
 	}

--- a/test/go_system_test.go
+++ b/test/go_system_test.go
@@ -135,12 +135,12 @@ func pushAndPop(t *testing.T, count int) {
 	}
 
 	util.Info("Done")
-	hash, err := cl.Info()
+	hash, err := cl.CurrentState()
 	if err != nil {
 		handleError(err)
 		return
 	}
-	util.Infof("%v", hash)
+	util.Infof("%+v", hash)
 }
 
 func pushJob(cl *client.Client, idx int) error {

--- a/util/json.go
+++ b/util/json.go
@@ -5,12 +5,19 @@ import (
 	"encoding/json"
 )
 
+func Must[T any](obj T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
 var (
 	// If true, activates encoding/json's Decoder and its UseNumber()
 	// option to preserve number precision.
 	// Defaults to false in Faktory 1.x.
 	// Will default to true in Faktory 2.x
-	JsonUseNumber bool = false
+	JsonUseNumber bool = Faktory2Preview
 )
 
 func JsonUnmarshal(data []byte, target any) error {

--- a/util/json.go
+++ b/util/json.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+var (
+	// If true, activates encoding/json's Decoder and its UseNumber()
+	// option to preserve number precision.
+	// Defaults to false in Faktory 1.x.
+	// Will default to true in Faktory 2.x
+	JsonUseNumber bool = false
+)
+
+func JsonUnmarshal(data []byte, target any) error {
+	if !JsonUseNumber {
+		return json.Unmarshal(data, target)
+	}
+
+	buf := bytes.NewBuffer(data)
+	dec := json.NewDecoder(buf)
+	dec.UseNumber()
+	return dec.Decode(target)
+}

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"cmp"
 	"context"
 	cryptorand "crypto/rand"
 	"encoding/base64"
@@ -8,6 +9,7 @@ import (
 	"math/big"
 	"os"
 	"runtime"
+	"strconv"
 	"time"
 )
 
@@ -18,6 +20,11 @@ const (
 	SIGTERM = 0xF
 
 	maxInt63 = int64(^uint64(0) >> 1)
+)
+
+var (
+	// Set FAKTORY2_PREVIEW=true to enable breaking changes coming in Faktory 2.0.
+	Faktory2Preview bool = Must(strconv.ParseBool(cmp.Or(os.Getenv("FAKTORY2_PREVIEW"), "false")))
 )
 
 func Retryable(ctx context.Context, name string, count int, fn func() error) error {

--- a/webui/helpers.go
+++ b/webui/helpers.go
@@ -143,7 +143,7 @@ func queueJobs(r *http.Request, q storage.Queue, count, currentPage uint64, fn f
 	c := r.Context()
 	err := q.Page(c, int64((currentPage-1)*count), int64(count), func(idx int, data []byte) error {
 		var job client.Job
-		err := json.Unmarshal(data, &job)
+		err := util.JsonUnmarshal(data, &job)
 		if err != nil {
 			util.Warnf("Error parsing JSON: %s", string(data))
 			return err
@@ -205,7 +205,7 @@ func busyReservations(req *http.Request, fn func(worker *manager.Reservation)) {
 	c := req.Context()
 	err := ctx(req).Store().Working().Each(c, func(idx int, entry storage.SortedEntry) error {
 		var res manager.Reservation
-		err := json.Unmarshal(entry.Value(), &res)
+		err := util.JsonUnmarshal(entry.Value(), &res)
 		if err != nil {
 			util.Error("Cannot unmarshal reservation", err)
 		} else {

--- a/webui/helpers_test.go
+++ b/webui/helpers_test.go
@@ -1,11 +1,11 @@
 package webui
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/contribsys/faktory/client"
+	"github.com/contribsys/faktory/util"
 )
 
 type testJob struct {
@@ -47,7 +47,7 @@ func makeActiveJob(jobType string) *client.Job {
 }
 `, jobType))
 	job := &client.Job{}
-	err := json.Unmarshal(payload, job)
+	err := util.JsonUnmarshal(payload, job)
 	if err != nil {
 		panic(err)
 	}
@@ -99,7 +99,7 @@ func makeActionMailerJob(jobType string, mailerClass string, mailerMethod string
 }
 `, jobType, mailerClass, mailerMethod))
 	job := &client.Job{}
-	err := json.Unmarshal(payload, job)
+	err := util.JsonUnmarshal(payload, job)
 	if err != nil {
 		panic(err)
 	}

--- a/webui/pages.go
+++ b/webui/pages.go
@@ -13,12 +13,12 @@ import (
 )
 
 func statsHandler(w http.ResponseWriter, r *http.Request) {
-	hash, err := ctx(r).Server().CurrentState()
+	thing, err := ctx(r).Server().CurrentState()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	data, err := json.Marshal(hash)
+	data, err := json.Marshal(thing)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/webui/pages_test.go
+++ b/webui/pages_test.go
@@ -58,19 +58,24 @@ func TestPages(t *testing.T) {
 			assert.Equal(t, 200, w.Code)
 			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 
-			var content map[string]interface{}
+			// data := w.Body.Bytes()
+			// fmt.Println(string(data))
+			var content client.FaktoryState
 			err = json.Unmarshal(w.Body.Bytes(), &content)
 			assert.NoError(t, err)
 
-			s := content["server"].(map[string]interface{})
-			uid := s["uptime"].(float64)
-			assert.Equal(t, float64(1234567), uid)
+			uid := content.Server.Uptime
+			assert.NoError(t, err)
+			assert.EqualValues(t, 1234567, uid)
 
-			queues := content["faktory"].(map[string]interface{})["queues"].(map[string]interface{})
-			defaultQ := queues["default"].(float64)
-			assert.Equal(t, 0.0, defaultQ)
-			foobarQ := queues["foobar"]
-			assert.Nil(t, foobarQ)
+			queues := content.Data.Queues
+			fmt.Println(queues)
+			defaultQ := queues["default"]
+			assert.NoError(t, err)
+			assert.EqualValues(t, 0, defaultQ)
+			foobarQ, ok := queues["foobar"]
+			assert.False(t, ok)
+			assert.EqualValues(t, 0, foobarQ)
 		})
 
 		t.Run("Queues", func(t *testing.T) {

--- a/webui/pages_test.go
+++ b/webui/pages_test.go
@@ -58,8 +58,6 @@ func TestPages(t *testing.T) {
 			assert.Equal(t, 200, w.Code)
 			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 
-			// data := w.Body.Bytes()
-			// fmt.Println(string(data))
 			var content client.FaktoryState
 			err = json.Unmarshal(w.Body.Bytes(), &content)
 			assert.NoError(t, err)
@@ -69,7 +67,6 @@ func TestPages(t *testing.T) {
 			assert.EqualValues(t, 1234567, uid)
 
 			queues := content.Data.Queues
-			fmt.Println(queues)
 			defaultQ := queues["default"]
 			assert.NoError(t, err)
 			assert.EqualValues(t, 0, defaultQ)
@@ -551,7 +548,6 @@ func findCSRFTokens(w http.ResponseWriter, body string) (string, string) {
 	// parse body token
 	results := searchBody.FindStringSubmatch(body)
 	if len(results) > 1 {
-		fmt.Println(results)
 		bodyToken = results[1]
 	}
 
@@ -561,7 +557,6 @@ func findCSRFTokens(w http.ResponseWriter, body string) (string, string) {
 		results2 := searchCookie.FindStringSubmatch(rawCookie)
 		if len(results2) > 1 {
 			cookieToken = results2[1]
-			fmt.Println(rawCookie)
 		}
 	}
 	return bodyToken, cookieToken


### PR DESCRIPTION
As #395 notes, unmarshalling JSON in Go can reduce precision for untyped numeric elements (`any` or `interface{}`) because it defaults to using Float64 as the type. We can lose precision as there are some Int64 values which can't be precisely represented as a Float64.

This PR aims to do the following:

1. Provide a means for the user to enable `Decoder.UseNumber()` so that Faktory will preserve numeric elements. This will be off by default in 1.x but can be enabled with a flag. This will be on by default in 2.x.
2. Reduce the use of untyped JSON hashes. The main offender here is the `client.Info()` command which returns a nasty `map[string]interface{}` requiring loads of type assertions. Not ergonomic or idiomatic. Instead we provide a new `client.CurrentState()` API which returns a client.FaktoryState structure which is almost entirely typed.

The test suite runs green locally with UseNumber = true or false.

Related to #395 