### PR TITLE
implement queue latency command

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,8 +2,13 @@
 
 Changelog: Faktory || [Faktory Enterprise](https://github.com/contribsys/faktory/blob/master/Ent-Changes.md)
 
-## HEAD
+## 1.9.2
 
+- Implement `QUEUE LATENCY` command:
+```
+> QUEUE LATENCY low default high
+=> {"low":8.14,"default":0.32,"high":0}
+```
 - Rejigger structs to use less memory via `betteralign`
 - Upgrade BurntSushi/toml to 1.4.0
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -138,7 +138,7 @@ func threadDump(s *server.Server) {
 	util.DumpProcessTrace()
 }
 
-func BuildServer(opts *CliOptions) (*server.Server, func(), error) {
+func BuildServer(opts *CliOptions) (*server.Server, func() error, error) {
 	globalConfig, err := readConfig(opts.ConfigDirectory, opts.Environment)
 	if err != nil {
 		return nil, nil, err

--- a/client/faktory.go
+++ b/client/faktory.go
@@ -2,7 +2,7 @@ package client
 
 var (
 	Name    = "Faktory"
-	Version = "1.9.1"
+	Version = "1.9.2"
 )
 
 // Structs for parsing the INFO response

--- a/server/commands_test.go
+++ b/server/commands_test.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/contribsys/faktory/client"
+	"github.com/contribsys/faktory/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommands(t *testing.T) {
+	util.LogInfo = true
+	util.LogDebug = true
+	runServer("localhost:4478", func(s *Server) {
+		t.Run("queue latency", func(t *testing.T) {
+			c := dummyConnection()
+			assert.NotNil(t, c.Context)
+
+			queue(c, s, "QUEUE LATENCY *")
+			txt := output(c)
+			assert.Equal(t, "-ERR QUEUE LATENCY does not support wildcards\r\n", txt)
+
+			queue(c, s, "QUEUE LATENCY default")
+			txt = output(c)
+			assert.Equal(t, "$13\r\n{\"default\":0}\r\n", txt)
+
+			ctx := c.Context
+			job := client.NewJob("jobtype", 1, 2, "mike")
+			assert.NoError(t, s.Manager().Push(ctx, job))
+
+			queue(c, s, "queue latency default foo")
+			txt = output(c)
+			assert.Regexp(t, regexp.MustCompile("\"default\":0.\\d{6}"), txt)
+			assert.Regexp(t, regexp.MustCompile("\"foo\":0"), txt)
+		})
+	})
+}

--- a/server/commands_test.go
+++ b/server/commands_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"encoding/json"
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -10,9 +12,42 @@ import (
 )
 
 func TestCommands(t *testing.T) {
-	util.LogInfo = true
-	util.LogDebug = true
+	// util.LogInfo = true
+	// util.LogDebug = true
 	runServer("localhost:4478", func(s *Server) {
+		t.Run("queue pause", func(t *testing.T) {
+			c := dummyConnection()
+			assert.NotNil(t, c.Context)
+
+			queue(c, s, "QUEUE PAUSE *")
+			txt := output(c)
+			assert.Equal(t, "+OK\r\n", txt)
+
+			queue(c, s, "QUEUE UNPAUSE *")
+			txt = output(c)
+			assert.Regexp(t, "^-ERR No such QUEUE subcommand", txt)
+
+			queue(c, s, "QUEUE RESUME *")
+			txt = output(c)
+			assert.Equal(t, "+OK\r\n", txt)
+
+			queue(c, s, "QUEUE REMOVE foo")
+			txt = output(c)
+			assert.Equal(t, "+OK\r\n", txt)
+
+			queue(c, s, "QUEUE REMOVE *")
+			txt = output(c)
+			assert.Equal(t, "+OK\r\n", txt)
+
+			queue(c, s, "QUEUE PAUSE default")
+			txt = output(c)
+			assert.Equal(t, "+OK\r\n", txt)
+
+			queue(c, s, "QUEUE RESUME default")
+			txt = output(c)
+			assert.Equal(t, "+OK\r\n", txt)
+		})
+
 		t.Run("queue latency", func(t *testing.T) {
 			c := dummyConnection()
 			assert.NotNil(t, c.Context)
@@ -31,8 +66,43 @@ func TestCommands(t *testing.T) {
 
 			queue(c, s, "queue latency default foo")
 			txt = output(c)
-			assert.Regexp(t, regexp.MustCompile("\"default\":0.\\d{6}"), txt)
+			assert.Regexp(t, regexp.MustCompile("\"default\":0.\\d{4}"), txt)
 			assert.Regexp(t, regexp.MustCompile("\"foo\":0"), txt)
+		})
+
+		t.Run("PUSHB", func(t *testing.T) {
+			jobs := []*client.Job{}
+			for range 10 {
+				job := client.NewJob("Mike", 1, 2, "foo")
+				jobs = append(jobs, job)
+			}
+
+			c := dummyConnection()
+			flush(c, s, "flush")
+			txt := output(c)
+			assert.Equal(t, "+OK\r\n", txt)
+
+			data, err := json.Marshal(jobs)
+			assert.NoError(t, err)
+			cmd := fmt.Sprintf("pushb %s", data)
+			pushBulk(c, s, cmd)
+			txt = output(c)
+			// no errors, all 10 pushed
+			assert.Equal(t, "$2\r\n{}\r\n", txt)
+			x, _ := s.CurrentState()
+			data, _ = json.Marshal(x)
+			util.Infof("State: %s", string(data))
+			qsize := x.Data.Queues["default"]
+			assert.EqualValues(t, 10, qsize)
+
+			job1 := jobs[0]
+			job1.Type = ""
+			data, err = json.Marshal(jobs)
+			assert.NoError(t, err)
+			cmd = fmt.Sprintf("pushb %s", data)
+			pushBulk(c, s, cmd)
+			txt = output(c)
+			assert.Equal(t, fmt.Sprintf("$57\r\n{\"%s\":\"jobs must have a jobtype parameter\"}\r\n", job1.Jid), txt)
 		})
 	})
 }

--- a/server/connection_test.go
+++ b/server/connection_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -66,9 +67,10 @@ func dummyConnection() *Connection {
 	wc := &TestingWriteCloser{output: writeBuffer, Writer: bufio.NewWriter(writeBuffer)}
 
 	return &Connection{
-		client: dummyClientData(),
-		conn:   wc,
-		buf:    bufio.NewReader(strings.NewReader("")),
+		client:  dummyClientData(),
+		conn:    wc,
+		buf:     bufio.NewReader(strings.NewReader("")),
+		Context: context.Background(),
 	}
 }
 

--- a/server/mutate_test.go
+++ b/server/mutate_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestMutateCommands(t *testing.T) {
-	runServer(":7419", func() {
-		// launch the Faktory server
+	runServer(":7419", func(*Server) {
 		cl, err := faktory.Open()
 		assert.NoError(t, err)
 

--- a/server/server.go
+++ b/server/server.go
@@ -208,7 +208,7 @@ func (s *Server) Stopper() chan bool {
 	return s.stopper
 }
 
-func (s *Server) Stop(f func()) {
+func (s *Server) Stop(onStop func()) {
 	// Don't allow new network connections
 	s.mu.Lock()
 	s.closed = true
@@ -219,8 +219,8 @@ func (s *Server) Stop(f func()) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	if f != nil {
-		f()
+	if onStop != nil {
+		onStop()
 	}
 
 	s.store.Close()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func runServer(binding string, runner func()) {
+func runServer(binding string, runner func(*Server)) {
 	dir := fmt.Sprintf("/tmp/%s", strings.Replace(binding, ":", "_", 1))
 	defer os.RemoveAll(dir)
 
@@ -50,12 +50,12 @@ func runServer(binding string, runner func()) {
 			panic(err)
 		}
 	}()
-	runner()
+	runner(s)
 	s.Stop(nil)
 }
 
 func TestServerStart(t *testing.T) {
-	runServer("localhost:4477", func() {
+	runServer("localhost:4477", func(s *Server) {
 		conn, err := net.DialTimeout("tcp", "localhost:4477", 1*time.Second)
 		assert.NoError(t, err)
 		buf := bufio.NewReader(conn)


### PR DESCRIPTION
Takes a list of queue names, names are case-sensitive. Returns Hash<String,Float>. Wildcards are not allowed. If a queue does not exist or is empty, it will get 0.

```
> queue latency default low critical
{"default":0,"low":0.003245,"critical":0.15}
```

Also fixes a long-standing bug in the test suite where Redis was not shutting down cleanly.

#497