### PR TITLE
Add optional `FAKTORY_WEBUI_PASSWORD` with argon2id, bcrypt, scrypt, and PBKDF2 support

### DIFF
--- a/cli/security_test.go
+++ b/cli/security_test.go
@@ -14,6 +14,13 @@ func pwdCfg(value string) map[string]any {
 		},
 	}
 }
+func webPwdCfg(value string) map[string]any {
+	return map[string]any{
+		"web": map[string]any{
+			"password": value,
+		},
+	}
+}
 
 func TestPasswords(t *testing.T) {
 	emptyCfg := map[string]any{}
@@ -27,6 +34,15 @@ func TestPasswords(t *testing.T) {
 		assert.Equal(t, 16, len(pwd))
 		assert.Equal(t, "cce29d6565ab7376", pwd)
 		assert.Equal(t, "********", cfg["faktory"].(map[string]any)["password"])
+	})
+
+	t.Run("DevWithWebPassword", func(t *testing.T) {
+		cfg := webPwdCfg(pwd)
+		pwd, err := fetchPassword(cfg, "development", passwordTypeWebUI)
+		assert.NoError(t, err)
+		assert.Equal(t, 16, len(pwd))
+		assert.Equal(t, "cce29d6565ab7376", pwd)
+		assert.Equal(t, "********", cfg["web"].(map[string]any)["password"])
 	})
 
 	t.Run("DevWithoutPassword", func(t *testing.T) {
@@ -70,6 +86,16 @@ func TestPasswords(t *testing.T) {
 
 	os.Unsetenv("FAKTORY_PASSWORD")
 
+	t.Run("ProductionEnvPassword", func(t *testing.T) {
+		os.Setenv("FAKTORY_WEBUI_PASSWORD", "webuipass")
+
+		pwd, err := fetchPassword(emptyCfg, "production", passwordTypeWebUI)
+		assert.NoError(t, err)
+		assert.Equal(t, "webuipass", pwd)
+	})
+
+	os.Unsetenv("FAKTORY_WEBUI_PASSWORD")
+
 	t.Run("ProductionSkipPassword", func(t *testing.T) {
 		os.Setenv("FAKTORY_SKIP_PASSWORD", "yes")
 
@@ -79,4 +105,5 @@ func TestPasswords(t *testing.T) {
 	})
 
 	os.Unsetenv("FAKTORY_SKIP_PASSWORD")
+
 }

--- a/cli/security_test.go
+++ b/cli/security_test.go
@@ -22,7 +22,7 @@ func TestPasswords(t *testing.T) {
 
 	t.Run("DevWithPassword", func(t *testing.T) {
 		cfg := pwdCfg(pwd)
-		pwd, err := fetchPassword(cfg, "development")
+		pwd, err := fetchPassword(cfg, "development", passwordTypeServer)
 		assert.NoError(t, err)
 		assert.Equal(t, 16, len(pwd))
 		assert.Equal(t, "cce29d6565ab7376", pwd)
@@ -30,13 +30,13 @@ func TestPasswords(t *testing.T) {
 	})
 
 	t.Run("DevWithoutPassword", func(t *testing.T) {
-		pwd, err := fetchPassword(emptyCfg, "development")
+		pwd, err := fetchPassword(emptyCfg, "development", passwordTypeServer)
 		assert.NoError(t, err)
 		assert.Equal(t, "", pwd)
 	})
 
 	t.Run("ProductionWithoutPassword", func(t *testing.T) {
-		pwd, err := fetchPassword(emptyCfg, "production")
+		pwd, err := fetchPassword(emptyCfg, "production", passwordTypeServer)
 		assert.Error(t, err)
 		assert.Equal(t, "", pwd)
 	})
@@ -46,14 +46,14 @@ func TestPasswords(t *testing.T) {
 		err := os.WriteFile("/tmp/test-password", []byte("foobar"), os.FileMode(0o666))
 		assert.NoError(t, err)
 		cfg := pwdCfg("/tmp/test-password")
-		pwd, err := fetchPassword(cfg, "production")
+		pwd, err := fetchPassword(cfg, "production", passwordTypeServer)
 		assert.NoError(t, err)
 		assert.Equal(t, "foobar", pwd)
 	})
 
 	t.Run("ProductionWithPassword", func(t *testing.T) {
 		cfg := pwdCfg(pwd)
-		pwd, err := fetchPassword(cfg, "production")
+		pwd, err := fetchPassword(cfg, "production", passwordTypeServer)
 		assert.NoError(t, err)
 		assert.Equal(t, 16, len(pwd))
 		assert.Equal(t, "cce29d6565ab7376", pwd)
@@ -63,7 +63,7 @@ func TestPasswords(t *testing.T) {
 	t.Run("ProductionEnvPassword", func(t *testing.T) {
 		os.Setenv("FAKTORY_PASSWORD", "abc123")
 
-		pwd, err := fetchPassword(emptyCfg, "production")
+		pwd, err := fetchPassword(emptyCfg, "production", passwordTypeServer)
 		assert.NoError(t, err)
 		assert.Equal(t, "abc123", pwd)
 	})
@@ -73,7 +73,7 @@ func TestPasswords(t *testing.T) {
 	t.Run("ProductionSkipPassword", func(t *testing.T) {
 		os.Setenv("FAKTORY_SKIP_PASSWORD", "yes")
 
-		pwd, err := fetchPassword(emptyCfg, "production")
+		pwd, err := fetchPassword(emptyCfg, "production", passwordTypeServer)
 		assert.NoError(t, err)
 		assert.Equal(t, "", pwd)
 	})

--- a/example/config.toml
+++ b/example/config.toml
@@ -1,3 +1,15 @@
+[faktory]
+# Required for production. Can use `FAKTORY_PASSWORD` env var instead
+password = "a-password-for-clients-to-connect-with"
+
+[web]
+# Optional. Specify to make the Web UI's HTTP Basic auth password different
+# from the Faktory server password clients connect with. Supports PHC-formatted
+# argon2id, bcrypt, scrypt, and pbkdf2 hashes and not just plaintext.
+# e.g. "$2b$12$xbQjW9Gtc35jLaAnGp7iV.PMoDuu0SdfWUrv30B6NT1vTrGc4LTPW"
+# Can use `FAKTORY_WEBUI_PASSWORD` env var instead.
+password = "an-optionally-different-http-basic-webui-password-from-faktory-server"
+
 [queues]
 # disable backpressure by default
 backpressure = 0

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/crypto v0.39.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
+golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/password/password.go
+++ b/password/password.go
@@ -1,9 +1,15 @@
 package password
 
 import (
+	"crypto/pbkdf2"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"hash"
 	"math"
 	"strings"
 
@@ -19,6 +25,7 @@ const (
 	hashIDBCrypt2  hashID = "2" // technically a major ver only
 	hashIDArgon2id hashID = "argon2id"
 	hashIDScrypt   hashID = "scrypt"
+	hashIDPBKDF2   hashID = "pbkdf2" // technically the first part of the identifier
 )
 
 // PasswordType interface describes the common way to verify a password for a
@@ -114,6 +121,37 @@ func (p scryptPasswordType) Verify(candidate string) (bool, error) {
 	return false, nil
 }
 
+type pbkdf2PasswordType struct {
+	basePasswordType
+	DigestFunc func() hash.Hash
+	Salt       []byte
+	Rounds     int
+	Key        []byte
+	KeyLen     int
+}
+
+func (p pbkdf2PasswordType) Verify(candidate string) (bool, error) {
+	candidateKey, err := pbkdf2.Key(
+		p.DigestFunc,
+		candidate,
+		p.Salt,
+		p.Rounds,
+		p.KeyLen,
+	)
+	candidateKeyLen := int32(len(candidateKey))
+
+	if err != nil {
+		return false, err
+	}
+	if subtle.ConstantTimeEq(int32(p.KeyLen), candidateKeyLen) == 0 {
+		return false, nil
+	}
+	if subtle.ConstantTimeCompare(p.Key, candidateKey) == 1 {
+		return true, nil
+	}
+	return false, nil
+}
+
 // Verify returns true if a `candidate` password matches the `configured` one,
 // which may or may not by hashed with different standardized hashing
 // algorithms. If an algorithm cannot be detected, it is assumed the
@@ -188,6 +226,47 @@ func detectHashAlgorithm(pwd string) (PasswordType, error) {
 		pt.KeyLen = len(pt.Key)
 		return pt, nil
 	}
+	if strings.HasPrefix(parts[1], string(hashIDPBKDF2)) {
+		digestIdent, found := strings.CutPrefix(parts[1], string(hashIDPBKDF2))
+		if !found {
+			return nil, errors.New("Could not find digest algo from PBKDF2 hash")
+		}
+		pt := pbkdf2PasswordType{}
+		pt.Hashed = pwd
+		switch digestIdent {
+		case "", "-sha1":
+			pt.DigestFunc = sha1.New
+		case "-sha256":
+			pt.DigestFunc = sha256.New
+		case "-sha512":
+			pt.DigestFunc = sha512.New
+		default:
+			return nil, fmt.Errorf("Unsupported digest ID %s for PBKDF2 hash", digestIdent)
+		}
+		_, err := fmt.Sscanf(parts[2], "%d", &pt.Rounds)
+		if err != nil {
+			return nil, err
+		}
+		salt, err := ab64Decode(parts[3])
+		if err != nil {
+			return nil, err
+		}
+		pt.Salt = salt
+		key, err := ab64Decode(parts[4])
+		if err != nil {
+			return nil, err
+		}
+		pt.Key = key
+		pt.KeyLen = len(pt.Key)
+		return pt, nil
+	}
 	util.Warnf("Unknown password hash algorithm ID %s, assuming plaintext", parts[1])
 	return ppt, nil
+}
+
+// ab64Decode from strict and raw base64 format which omits padding &
+// whitespace. Supports both custom ./ and normal +/ altchars.
+func ab64Decode(s string) ([]byte, error) {
+	b64s := strings.ReplaceAll(s, ".", "+")
+	return base64.RawStdEncoding.Strict().DecodeString(b64s)
 }

--- a/password/password.go
+++ b/password/password.go
@@ -48,7 +48,7 @@ func verifyAgainstHash(password string, hashedPassword string) (bool, error) {
 }
 
 func verifyAgainstPlaintext(pwd1 string, pwd2 string) bool {
-	return subtle.ConstantTimeCompare([]byte(pwd1), []byte(pwd2)) != 1
+	return subtle.ConstantTimeCompare([]byte(pwd1), []byte(pwd2)) == 1
 }
 
 // isSupportedPasswordHash returns true if the supplied password is actually a

--- a/password/password.go
+++ b/password/password.go
@@ -77,11 +77,7 @@ func (p argon2idPasswordType) Verify(candidate string) (bool, error) {
 		p.Threads,
 		uint32(p.KeyLen),
 	)
-	candidateKeyLen := int32(len(candidateKey))
 
-	if subtle.ConstantTimeEq(p.KeyLen, candidateKeyLen) == 0 {
-		return false, nil
-	}
 	if subtle.ConstantTimeCompare(p.Key, candidateKey) == 1 {
 		return true, nil
 	}
@@ -107,13 +103,9 @@ func (p scryptPasswordType) Verify(candidate string) (bool, error) {
 		p.Parallelism,
 		p.KeyLen,
 	)
-	candidateKeyLen := int32(len(candidateKey))
 
 	if err != nil {
 		return false, err
-	}
-	if subtle.ConstantTimeEq(int32(p.KeyLen), candidateKeyLen) == 0 {
-		return false, nil
 	}
 	if subtle.ConstantTimeCompare(p.Key, candidateKey) == 1 {
 		return true, nil
@@ -138,13 +130,9 @@ func (p pbkdf2PasswordType) Verify(candidate string) (bool, error) {
 		p.Rounds,
 		p.KeyLen,
 	)
-	candidateKeyLen := int32(len(candidateKey))
 
 	if err != nil {
 		return false, err
-	}
-	if subtle.ConstantTimeEq(int32(p.KeyLen), candidateKeyLen) == 0 {
-		return false, nil
 	}
 	if subtle.ConstantTimeCompare(p.Key, candidateKey) == 1 {
 		return true, nil

--- a/password/password.go
+++ b/password/password.go
@@ -1,0 +1,78 @@
+package password
+
+import (
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+type hashID string
+
+const (
+	hashIDBCrypt2 hashID = "2" // technically a major ver only
+)
+
+type HashAlgorithmType string
+
+const (
+	HashAlgorithmTypeBCrypt  HashAlgorithmType = "bcrypt"
+	HashAlgorithmTypeArgon   HashAlgorithmType = "argon"
+	HashAlgorithmTypeUnknown HashAlgorithmType = ""
+)
+
+func Verify(candidate string, configured string) (bool, error) {
+	if isSupportedPasswordHash(configured) {
+		return verifyAgainstHash(candidate, configured)
+	} else {
+		return verifyAgainstPlaintext(candidate, configured), nil
+	}
+}
+
+func verifyAgainstHash(password string, hashedPassword string) (bool, error) {
+	algo, err := detectHashAlgorithm(hashedPassword)
+	if err != nil {
+		return false, err
+	}
+	if algo == HashAlgorithmTypeBCrypt {
+		err = bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
+		if err != nil {
+			return false, err
+		} else {
+			return true, nil
+		}
+	}
+	panic(fmt.Sprintf("Password hash algorithm not implemented: %s", algo))
+}
+
+func verifyAgainstPlaintext(pwd1 string, pwd2 string) bool {
+	return subtle.ConstantTimeCompare([]byte(pwd1), []byte(pwd2)) != 1
+}
+
+// isSupportedPasswordHash returns true if the supplied password is actually a
+// hash as defined by the PHC format that Faktory supports. Per OWASP guidance,
+// only Argon2id, scrypt, bcrypt, and PBKDF2 hashes are supported.
+//
+// https://github.com/P-H-C/phc-string-format
+// https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+func isSupportedPasswordHash(pwd string) bool {
+	algo, err := detectHashAlgorithm(pwd)
+	if err != nil {
+		return false
+	}
+	return algo != HashAlgorithmTypeUnknown
+}
+
+func detectHashAlgorithm(pwd string) (HashAlgorithmType, error) {
+	// TODO: do a fulsome parsing of PHC format
+	parts := strings.Split(pwd, "$")
+	if parts[0] != "" || len(parts) < 2 || len(parts[1]) < 1 {
+		return HashAlgorithmTypeUnknown, errors.New("not a recognizable password hash format")
+	}
+	if hashID(parts[1][0]) == hashIDBCrypt2 {
+		return HashAlgorithmTypeBCrypt, nil
+	}
+	return HashAlgorithmTypeUnknown, fmt.Errorf("unknown password hash algorithm id %s", parts[1])
+}

--- a/password/password.go
+++ b/password/password.go
@@ -15,12 +15,12 @@ const (
 	hashIDBCrypt2 hashID = "2" // technically a major ver only
 )
 
-type HashAlgorithmType string
+type hashAlgorithmType string
 
 const (
-	HashAlgorithmTypeBCrypt  HashAlgorithmType = "bcrypt"
-	HashAlgorithmTypeArgon   HashAlgorithmType = "argon"
-	HashAlgorithmTypeUnknown HashAlgorithmType = ""
+	hashAlgorithmTypeBCrypt  hashAlgorithmType = "bcrypt"
+	hashAlgorithmTypeArgon   hashAlgorithmType = "argon"
+	hashAlgorithmTypeUnknown hashAlgorithmType = ""
 )
 
 func Verify(candidate string, configured string) (bool, error) {
@@ -36,7 +36,7 @@ func verifyAgainstHash(password string, hashedPassword string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if algo == HashAlgorithmTypeBCrypt {
+	if algo == hashAlgorithmTypeBCrypt {
 		err = bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
 		if err != nil {
 			return false, err
@@ -62,17 +62,17 @@ func isSupportedPasswordHash(pwd string) bool {
 	if err != nil {
 		return false
 	}
-	return algo != HashAlgorithmTypeUnknown
+	return algo != hashAlgorithmTypeUnknown
 }
 
-func detectHashAlgorithm(pwd string) (HashAlgorithmType, error) {
+func detectHashAlgorithm(pwd string) (hashAlgorithmType, error) {
 	// TODO: do a fulsome parsing of PHC format
 	parts := strings.Split(pwd, "$")
 	if parts[0] != "" || len(parts) < 2 || len(parts[1]) < 1 {
-		return HashAlgorithmTypeUnknown, errors.New("not a recognizable password hash format")
+		return hashAlgorithmTypeUnknown, errors.New("not a recognizable password hash format")
 	}
 	if hashID(parts[1][0]) == hashIDBCrypt2 {
-		return HashAlgorithmTypeBCrypt, nil
+		return hashAlgorithmTypeBCrypt, nil
 	}
-	return HashAlgorithmTypeUnknown, fmt.Errorf("unknown password hash algorithm id %s", parts[1])
+	return hashAlgorithmTypeUnknown, fmt.Errorf("unknown password hash algorithm id %s", parts[1])
 }

--- a/password/password_test.go
+++ b/password/password_test.go
@@ -58,6 +58,42 @@ func TestPasswordVerify(t *testing.T) {
 				verified:   false,
 			},
 			{
+				name:       "pbkdf2-hmac-sha1 correct",
+				candidate:  "a",
+				configured: "$pbkdf2$131000$j3FurVUqxbiXUuqdc865Fw$khjQ9RJHk0901AZmqtUnudHQmDg",
+				verified:   true,
+			},
+			{
+				name:       "pbkdf2-hmac-sha1 incorrect",
+				candidate:  "wrong",
+				configured: "$pbkdf2$131000$j3FurVUqxbiXUuqdc865Fw$khjQ9RJHk0901AZmqtUnudHQmDg",
+				verified:   false,
+			},
+			{
+				name:       "pbkdf2-hmac-sha256 correct",
+				candidate:  "a",
+				configured: "$pbkdf2-sha256$29000$EqJUqlXqfa/13hsDYGyNsQ$mySn2pP1vbxyIA2/ExJqoHDc0ywnwf4SSJPavT6n3oA",
+				verified:   true,
+			},
+			{
+				name:       "pbkdf2-hmac-sha256 incorrect",
+				candidate:  "wrong",
+				configured: "$pbkdf2-sha256$29000$EqJUqlXqfa/13hsDYGyNsQ$mySn2pP1vbxyIA2/ExJqoHDc0ywnwf4SSJPavT6n3oA",
+				verified:   false,
+			},
+			{
+				name:       "pbkdf2-hmac-sha512 correct",
+				candidate:  "a",
+				configured: "$pbkdf2-sha512$25000$QmhtjZEyJuR8r3UOoVRKaQ$EiqzPjoOZkEt3SKVZv9g31/kaj8WXIaey5pNWWVczZrJXXeuA9CU.vlJ3AgYS6CqojXtpgC1P0kJwkevKDMqMw",
+				verified:   true,
+			},
+			{
+				name:       "pbkdf2-hmac-sha512 incorrect",
+				candidate:  "wrong",
+				configured: "$pbkdf2-sha512$25000$QmhtjZEyJuR8r3UOoVRKaQ$EiqzPjoOZkEt3SKVZv9g31/kaj8WXIaey5pNWWVczZrJXXeuA9CU.vlJ3AgYS6CqojXtpgC1P0kJwkevKDMqMw",
+				verified:   false,
+			},
+			{
 				name:       "plaintext correct",
 				candidate:  "a",
 				configured: "a",
@@ -80,15 +116,20 @@ func TestPasswordVerify(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v, err := Verify(tt.candidate, tt.configured)
-			if v != tt.verified {
-				t.Errorf("Verify(\"%s\", \"%s\") = %v; want %v", tt.candidate, tt.configured, v, tt.verified)
-			}
+
 			if tt.expectErr {
 				if err == nil {
 					t.Fatalf("expected error but got nil")
 				}
 				if err.Error() != tt.errMessage {
 					t.Errorf("expected error %q, got %q", tt.errMessage, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("did not expect error, got %q", err.Error())
+				}
+				if v != tt.verified {
+					t.Errorf("Verify(\"%s\", \"%s\") = %v; want %v", tt.candidate, tt.configured, v, tt.verified)
 				}
 			}
 		})

--- a/password/password_test.go
+++ b/password/password_test.go
@@ -1,0 +1,96 @@
+package password
+
+import (
+	"testing"
+)
+
+// PHC-formatted hashes produced using Python's `passlib` library:
+//
+//	from passlib import hash
+//	hash.bcrypt.hash("a") # => "$2b$12$xbQjW9Gtc35jLaAnGp7iV.PMoDuu0SdfWUrv30B6NT1vTrGc4LTPW"
+//	hash.scrypt.hash("a") # => "$scrypt$ln=16,r=8,p=1$AaAU4tybc06JUcoZo1RK6Q$xsBBX09sq48k30ngJqoUepwYM3T/HJn9K7eYzgIyNbw"
+func TestPasswordVerify(t *testing.T) {
+	tests :=
+		[]struct {
+			name       string
+			candidate  string
+			configured string
+			verified   bool
+			expectErr  bool
+			errMessage string
+		}{
+			{
+				name:       "bcrypt correct",
+				candidate:  "a",
+				configured: "$2b$12$xbQjW9Gtc35jLaAnGp7iV.PMoDuu0SdfWUrv30B6NT1vTrGc4LTPW",
+				verified:   true,
+			},
+			{
+				name:       "bcrypt incorrect",
+				candidate:  "wrong",
+				configured: "$2b$12$xbQjW9Gtc35jLaAnGp7iV.PMoDuu0SdfWUrv30B6NT1vTrGc4LTPW",
+				verified:   false,
+				expectErr:  true,
+				errMessage: "crypto/bcrypt: hashedPassword is not the hash of the given password",
+			},
+			{
+				name:       "argon2id correct",
+				candidate:  "a",
+				configured: "$argon2id$v=19$m=65536,t=3,p=4$VSrlfE9pLcW4977XGiOklA$GIIN05JoObiRMLBpP+iPBHeemyovXJvM4Zi2JU82XFg",
+				verified:   true,
+			},
+			{
+				name:       "argon2id incorrect",
+				candidate:  "wrong",
+				configured: "$argon2id$v=19$m=65536,t=3,p=4$VSrlfE9pLcW4977XGiOklA$GIIN05JoObiRMLBpP+iPBHeemyovXJvM4Zi2JU82XFg",
+				verified:   false,
+			},
+			{
+				name:       "scrypt correct",
+				candidate:  "a",
+				configured: "$scrypt$ln=16,r=8,p=1$AaAU4tybc06JUcoZo1RK6Q$xsBBX09sq48k30ngJqoUepwYM3T/HJn9K7eYzgIyNbw",
+				verified:   true,
+			},
+			{
+				name:       "scrypt incorrect",
+				candidate:  "wrong",
+				configured: "$scrypt$ln=16,r=8,p=1$AaAU4tybc06JUcoZo1RK6Q$xsBBX09sq48k30ngJqoUepwYM3T/HJn9K7eYzgIyNbw",
+				verified:   false,
+			},
+			{
+				name:       "plaintext correct",
+				candidate:  "a",
+				configured: "a",
+				verified:   true,
+			},
+			{
+				name:       "plaintext incorrect",
+				candidate:  "wrong",
+				configured: "a",
+				verified:   false,
+			},
+			{
+				name:       "PHC-ish looking plaintext",
+				candidate:  "$bcrypt$tography",
+				configured: "$bcrypt$tography",
+				verified:   true,
+			},
+		}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := Verify(tt.candidate, tt.configured)
+			if v != tt.verified {
+				t.Errorf("Verify(\"%s\", \"%s\") = %v; want %v", tt.candidate, tt.configured, v, tt.verified)
+			}
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+				if err.Error() != tt.errMessage {
+					t.Errorf("expected error %q, got %q", tt.errMessage, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/server/config.go
+++ b/server/config.go
@@ -1,6 +1,8 @@
 package server
 
-import "github.com/contribsys/faktory/util"
+import (
+	"github.com/contribsys/faktory/util"
+)
 
 // This is the ultimate scalability limitation in Faktory,
 // we only allow this many connections to Redis.
@@ -14,6 +16,7 @@ type ServerOptions struct {
 	ConfigDirectory  string
 	Environment      string
 	Password         string
+	WebUIPassword    string
 	PoolSize         uint64
 }
 

--- a/webui/web.go
+++ b/webui/web.go
@@ -337,7 +337,7 @@ func basicAuth(srvPwd string, pass http.HandlerFunc) http.HandlerFunc {
 		verified, err := password.Verify(pwd, srvPwd)
 		if !verified {
 			if err != nil {
-				util.Error("Failed password verification", err)
+				util.Error("Error during password verification", err)
 			}
 			w.Header().Set("WWW-Authenticate", `Basic realm="Faktory"`)
 			http.Error(w, "Authorization failed", http.StatusUnauthorized)


### PR DESCRIPTION
Closes #510 

New functionality:

1. `FAKTORY_WEBUI_PASSWORD` can be specified. If set, it will configure the Web UI with that password otherwise will fallback to `FAKTORY_PASSWORD` value. This is the existing behaviour for the undocumented TOML config `[web]` subsystem's `password` element.
2. If the configured Web UI password string conforms to the Password Hashing Competition (PHC)'s format and a supported hashing algorithm is identified, the HTTP Basic Auth password will be hashed and compared accordingly. Otherwise plaintext is assumed and is string compared normally.

Rationale:

1. [The PHC format](https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md) is a looser version of the well known [Binary Modular Crypt Format (BMCF)](https://github.com/ademarre/binary-mcf) that we've seen in `/etc/shadow` after all these years. It's considered the _de facto_ standard for representing password hashes in a non-standardized world of password hashing. It's what's used by Argon2 and the likes. Popular hashing libraries like Python's [passlib](https://passlib.readthedocs.io/en/stable/) use it and should come as no surprise to developers using Faktory.
2. [OWASP's current guidance](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) for password hashing algorithms are argon2id, bcrypt, scrypt, and PBKDF2. These are considered still secure algos (when parameters properly set) and seem like a good set to support.
3. The algos are all available in the officially supported `golang.org/x/crypto` module, so we can trust the implementations are cryptographically correct.
